### PR TITLE
Refactor code to make adding tests easier

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -74,6 +74,10 @@ let package = Package(
             name: "LLBBuildSystemTestHelpers",
             dependencies: ["LLBBuildSystem"]
         ),
+        .testTarget(
+            name: "LLBBuildSystemTests",
+            dependencies: ["LLBBuildSystemTestHelpers"]
+        ),
 
         // Command line tools
         .target(

--- a/Sources/LLBBuildSystem/BuildEngineContext.swift
+++ b/Sources/LLBBuildSystem/BuildEngineContext.swift
@@ -11,14 +11,21 @@ import LLBExecutionProtocol
 
 /// LLBBuildEngineContext contains references to dependencies that may need to be used throught the evaluation of the
 /// functions.
-public class LLBBuildEngineContext {
+public protocol LLBBuildEngineContext {
     /// The dispatch group to be used as when processing the future blocks throught the build.
-    public let group: LLBFuturesDispatchGroup
+    var group: LLBFuturesDispatchGroup { get }
 
     /// The CAS database reference to use for interfacing with CAS systems.
-    public let db: LLBCASDatabase
+    var db: LLBCASDatabase { get }
 
     /// A reference to an executor that provides action execution support.
+    var executor: LLBExecutor { get }
+}
+
+/// Basic build engine context implementation.
+public class LLBBasicBuildEngineContext: LLBBuildEngineContext {
+    public let group: LLBFuturesDispatchGroup
+    public let db: LLBCASDatabase
     public let executor: LLBExecutor
 
     public init(group: LLBFuturesDispatchGroup, db: LLBCASDatabase, executor: LLBExecutor) {

--- a/Sources/LLBBuildSystem/Function.swift
+++ b/Sources/LLBBuildSystem/Function.swift
@@ -1,0 +1,57 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import llbuild2
+
+public enum LLBBuildFunctionError: Error {
+    case unexpectedKeyType(String)
+}
+
+/// An "abstract" class that represents a build function, which includes the engineContext reference and a way to
+/// statically specify the types of the build keys and values.
+open class LLBBuildFunction<K: LLBBuildKey, V: LLBBuildValue>: LLBFunction {
+    public let engineContext: LLBBuildEngineContext
+
+    public init(engineContext: LLBBuildEngineContext) {
+        self.engineContext = engineContext
+    }
+
+    public final func compute(key: LLBKey, _ fi: LLBFunctionInterface) -> LLBFuture<LLBValue> {
+        if let key = key as? K {
+            return evaluate(key: key, LLBBuildFunctionInterface(fi: fi)).map { $0 }
+        } else {
+            return engineContext.group.next().makeFailedFuture(
+                LLBBuildFunctionError.unexpectedKeyType("Expected type \(String(describing: K.self)), but got \(String(describing: type(of: key)))")
+            )
+        }
+    }
+
+    /// Subclasses of LLBBuildFunction should override this method to provide the actual implementation of the function.
+    open func evaluate(key: K, _ fi: LLBBuildFunctionInterface) -> LLBFuture<V> {
+        fatalError("This needs to be implemented by subclasses.")
+    }
+}
+
+/// A wrapper for the LLBFunctionInterface build system and static type support for build functions.
+public final class LLBBuildFunctionInterface {
+    let fi: LLBFunctionInterface
+
+    init(fi: LLBFunctionInterface) {
+        self.fi = fi
+    }
+
+    /// Requests the value for a build key.
+    func request<K: LLBBuildKey>(_ key: K) -> LLBFuture<LLBBuildValue> {
+        return self.fi.request(key).map { $0 as! LLBBuildValue }
+    }
+
+    /// Requests the value for a build key.
+    func request<K: LLBBuildKey, V: LLBBuildValue>(_ key: K, as valueType: V.Type = V.self) -> LLBFuture<V> {
+        return self.fi.request(key).map { $0 as! V }
+    }
+}

--- a/Sources/LLBBuildSystem/FunctionDelegate.swift
+++ b/Sources/LLBBuildSystem/FunctionDelegate.swift
@@ -1,0 +1,17 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import llbuild2
+
+/// Protocol definition for a delegate that provides the function implementation for processing a type of build key.
+public protocol LLBBuildFunctionLookupDelegate {
+
+    /// Returns the function to use to evaluate that type of identifier, or nil if the delegate does not know how to
+    /// process such build key.
+    func lookupBuildFunction(for identifier: LLBBuildKeyIdentifier) -> LLBFunction?
+}

--- a/Tests/LLBBuildSystemTests/LLBBuildEngineTests.swift
+++ b/Tests/LLBBuildSystemTests/LLBBuildEngineTests.swift
@@ -1,0 +1,63 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import llbuild2
+import LLBBuildSystem
+import LLBBuildSystemTestHelpers
+
+import XCTest
+
+/// Key requesting the addition of some numbers. In order to maximize cacheability, the numbers should be sorted.
+struct SumKey: LLBBuildKey {
+    static let identifier = String(describing: Self.self)
+
+    let numbers: [Int]
+}
+
+extension Int: LLBBuildValue {}
+
+/// A build function that sums the numbers specified in the build key.
+class SumFunction: LLBBuildFunction<SumKey, Int> {
+    override func evaluate(key sumKey: SumKey, _ fi: LLBBuildFunctionInterface) -> LLBFuture<Int> {
+        return engineContext.group.next().makeSucceededFuture(sumKey.numbers.reduce(0, +))
+    }
+}
+
+/// A function map supporting different kinds of mathematical expressions.
+class MathematicsFunctionMap: LLBBuildFunctionLookupDelegate {
+    let functionMap: [LLBBuildKeyIdentifier: LLBFunction]
+
+    init(engineContext: LLBBuildEngineContext) {
+        self.functionMap = [
+            SumKey.identifier: SumFunction(engineContext: engineContext)
+        ]
+    }
+
+    func lookupBuildFunction(for identifier: LLBBuildKeyIdentifier) -> LLBFunction? {
+        return self.functionMap[identifier]
+    }
+}
+
+class LLBBuildEngineTests: XCTestCase {
+    func testFunctionResolutionFailure() throws {
+        let testEngine = LLBTestBuildEngine()
+
+        XCTAssertThrowsError(try testEngine.build(SumKey(numbers: [1, 2, 3])).wait()) { error in
+            XCTAssertEqual(error as? LLBBuildEngineError, LLBBuildEngineError.unknownBuildKeyIdentifier("SumKey"))
+        }
+    }
+
+    func testSimpleMathBuild() throws {
+        let testEngineContext = LLBTestBuildEngineContext()
+        let testEngine = LLBTestBuildEngine(buildFunctionLookupDelegate: MathematicsFunctionMap(engineContext: testEngineContext))
+
+        let result = try XCTUnwrap(testEngine.build(SumKey(numbers: [1, 2, 3])).wait() as Int)
+
+        XCTAssertEqual(result, 6)
+    }
+}


### PR DESCRIPTION
This PR adds 4 commits that were required to add easy test support for the build system engine.

1: Adds support for dynamic resolution of build functions
2: Adds abstract LLBBuildFunction for a build specific interface
3: Refactor engine context into a protocol for easier usage
4: Adds basic test for the build system engine

The tests for now are super simple and could be implemeneted in the llbuild2 core engine instead, and as the CAS pieces start appearing, we'll be making use of those instead.