### PR TITLE
Add FileBackedCASDatabase

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -72,6 +72,7 @@ let package = Package(
                 "SwiftToolsSupport-auto",
                 "BazelRemoteAPI",
                 "llbuild2",
+                "LLBUtil",
             ]
         ),
 

--- a/Sources/LLBRETool/Options.swift
+++ b/Sources/LLBRETool/Options.swift
@@ -11,14 +11,14 @@ import Foundation
 
 public struct Options {
     // FIXME: We should also support specifying specific endpoints for individual services.
-    /// The frontend target for all services (CAS, Action Cache, Execution).
-    public var frontend: ConnectionTarget
+    /// The frontend URL for all services (CAS, Action Cache, Execution).
+    public var frontend: URL
 
     /// Custom gRPC headers to send with each request.
     public var grpcHeaders: [GRPCHeader]
 
     public init(
-        frontend: ConnectionTarget,
+        frontend: URL,
         grpcHeaders: [GRPCHeader] = []
     ) {
         self.frontend = frontend

--- a/Sources/LLBUtil/CAS/FileBackedCASDatabase.swift
+++ b/Sources/LLBUtil/CAS/FileBackedCASDatabase.swift
@@ -1,0 +1,109 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import llbuild2
+import TSCBasic
+import TSCLibc
+import Foundation
+
+public final class LLBFileBackedCASDatabase: LLBCASDatabase {
+    /// Prefix for files written to disk.
+    enum FileNamePrefix: String {
+        case refs = "refs."
+        case data = "data."
+    }
+
+    /// The content root path.
+    public let path: AbsolutePath
+
+    /// Threads capable of running futures.
+    public let group: LLBFuturesDispatchGroup
+
+    public init(
+        group: LLBFuturesDispatchGroup,
+        path: AbsolutePath
+    ) {
+        self.group = group
+        self.path = path
+        try? localFileSystem.createDirectory(path, recursive: true)
+    }
+
+    private func fileName(for id: LLBDataID, prefix: FileNamePrefix) -> AbsolutePath {
+        return path.appending(component: prefix.rawValue + id.debugDescription)
+    }
+
+    public func supportedFeatures() -> LLBFuture<LLBCASFeatures> {
+        group.next().makeSucceededFuture(LLBCASFeatures(preservesIDs: true))
+    }
+
+    public func contains(_ id: LLBDataID) -> LLBFuture<Bool> {
+        let refsFile = fileName(for: id, prefix: .refs)
+        let dataFile = fileName(for: id, prefix: .data)
+        let contains = localFileSystem.exists(refsFile) && localFileSystem.exists(dataFile)
+        return group.next().makeSucceededFuture(contains)
+    }
+
+    public func get(_ id: LLBDataID) -> LLBFuture<LLBCASObject?> {
+        let refsFile = fileName(for: id, prefix: .refs)
+        let dataFile = fileName(for: id, prefix: .data)
+
+        do {
+            let data = try fs.readFileContents(dataFile)
+            let refsData = try fs.readFileContents(refsFile)
+            let refs = try JSONDecoder().decode([LLBDataID].self, from: Data(refsData.contents))
+            let result = LLBCASObject(refs: refs, data: LLBByteBuffer.withBytes(data.contents[...]))
+            return group.next().makeSucceededFuture(result)
+        } catch {
+            return group.next().makeFailedFuture(error)
+        }
+    }
+
+    var fs: FileSystem { localFileSystem }
+
+    public func put(refs: [LLBDataID], data: LLBByteBuffer) -> LLBFuture<LLBDataID> {
+        put(knownID: LLBDataID(blake3hash: data, refs: refs), refs: refs, data: data)
+    }
+
+    public func put(knownID id: LLBDataID, refs: [LLBDataID], data: LLBByteBuffer) -> LLBFuture<LLBDataID> {
+        do {
+            let refsFile = fileName(for: id, prefix: .refs)
+            let dataFile = fileName(for: id, prefix: .data)
+
+            var sbData = stat()
+            var sbRefs = stat()
+            if stat(dataFile.pathString, &sbData) != -1 && stat(refsFile.pathString, &sbRefs) != -1 {
+                // Assume some amount of file system atomicity, which means
+                // that if we have this file, then:
+                // 1. This file was properly written to completion, and reading
+                //    from it will result in getting all the data.
+                // 2. The references `refs` were written even earlier, and are
+                //    also available.
+                // One would only wish that these guarantees were available...
+                assert(sbData.st_size == data.readableBytes, "Replacing \(id) with data of different length")
+                return group.next().makeSucceededFuture(id)
+            }
+
+            let data = data.getBytes(at: 0, length: data.readableBytes)!
+            try localFileSystem.writeFileContents(
+                dataFile,
+                bytes: ByteString(data),
+                atomically: true
+            )
+
+            let refData = try JSONEncoder().encode(refs)
+            try localFileSystem.writeFileContents(
+                refsFile,
+                bytes: ByteString(refData),
+                atomically: true
+            )
+            return group.next().makeSucceededFuture(id)
+        } catch {
+            return group.next().makeFailedFuture(error)
+        }
+    }
+}

--- a/Sources/Tools/retool/CAS.swift
+++ b/Sources/Tools/retool/CAS.swift
@@ -1,0 +1,69 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import TSCBasic
+import Foundation
+import ArgumentParser
+import llbuild2
+import GRPC
+import LLBRETool
+
+struct CAS: ParsableCommand {
+    static let configuration: CommandConfiguration = CommandConfiguration(
+        abstract: "Perform operations of the CAS database",
+        subcommands: [
+            CASGet.self,
+            CASPut.self,
+        ]
+    )
+}
+
+struct CASPut: ParsableCommand {
+    static let configuration: CommandConfiguration = CommandConfiguration(
+        commandName: "put",
+        abstract: "Put the given file into the CAS database"
+    )
+
+    @OptionGroup()
+    var options: Options
+
+    @Argument()
+    var path: AbsolutePath
+
+    func run() throws {
+        let toolOptions = self.options.toToolOptions()
+        let tool = RETool(toolOptions)
+        try tool.casPut(file: path)
+    }
+}
+
+struct CASGet: ParsableCommand {
+    static let configuration: CommandConfiguration = CommandConfiguration(
+        commandName: "get",
+        abstract: "Get a file from the CAS database given a data id"
+    )
+
+    @OptionGroup()
+    var options: Options
+
+    @Option()
+    var id: String
+
+    @Argument()
+    var path: AbsolutePath
+
+    func run() throws {
+        guard let id = LLBDataID(string: self.id) else {
+            throw StringError("Invalid data id \(self.id)")
+        }
+
+        let toolOptions = self.options.toToolOptions()
+        let tool = RETool(toolOptions)
+        try tool.casGet(id: id, to: path)
+    }
+}

--- a/Sources/Tools/retool/Capabilities.swift
+++ b/Sources/Tools/retool/Capabilities.swift
@@ -25,7 +25,7 @@ struct Capabilities: ParsableCommand {
     var instanceName: String?
 
     func run() throws {
-        let toolOptions = try self.options.toToolOptions()
+        let toolOptions = self.options.toToolOptions()
         let tool = RETool(toolOptions)
 
         let response = try tool.getCapabilities(instanceName: instanceName).wait()
@@ -34,11 +34,9 @@ struct Capabilities: ParsableCommand {
 }
 
 extension Options {
-    func toToolOptions() throws -> LLBRETool.Options {
-        let frontendTarget = try url.toConnectionTarget()
-
+    func toToolOptions() -> LLBRETool.Options {
         return LLBRETool.Options(
-            frontend: frontendTarget,
+            frontend: url,
             grpcHeaders: grpcHeader
         )
     }

--- a/Sources/Tools/retool/main.swift
+++ b/Sources/Tools/retool/main.swift
@@ -14,6 +14,7 @@ struct REToolCommand: ParsableCommand {
         abstract: "retool — remote execution tool",
         subcommands: [
             Capabilities.self,
+            CAS.self,
         ]
     )
 }

--- a/Sources/Tools/retool/misc.swift
+++ b/Sources/Tools/retool/misc.swift
@@ -21,15 +21,14 @@ extension URL: ExpressibleByArgument {
     }
 }
 
-extension URL {
-    func toConnectionTarget() throws -> ConnectionTarget {
-        // FIXME: Support unix scheme?
-        guard let host = self.host else {
-            throw StringError("no host in url \(self)")
+extension AbsolutePath: ExpressibleByArgument {
+    public init?(argument: String) {
+        if let path = try? AbsolutePath(validating: argument) {
+            self = path
+        } else if let cwd = localFileSystem.currentWorkingDirectory {
+            self = AbsolutePath(argument, relativeTo: cwd)
+        } else {
+            return nil
         }
-        guard let port = self.port else {
-            throw StringError("no port in url \(self)")
-        }
-        return .hostAndPort(host, port)
     }
 }


### PR DESCRIPTION
This adds an implementation for file-backed CAS database that isn't
particularly efficient but useful for performing tests. This also adds
support for writing and reading to file-backed CAS using `retool cas`
subtool.

The cas subtool only operates on the file-backed CAS right now but that
can be evolved over time as we implement more CAS databases.