### PR TITLE
Fix upload of static writes and actions into the CAS to ensure it happens after artifact updates

### DIFF
--- a/Protos/BuildSystem/Evaluation/artifact_owner.proto
+++ b/Protos/BuildSystem/Evaluation/artifact_owner.proto
@@ -10,13 +10,17 @@ syntax = "proto3";
 
 import "CASProtocol/data_id.proto";
 
-/// An ArtifactOwner contains the reference to the action that generates an artifact, effectively providing the link
-/// between artifacts and actions that make up the action graph.
+// An ArtifactOwner contains the reference to the action that generates an artifact, effectively providing the link
+// between artifacts and actions that make up the action graph.
 message LLBArtifactOwner {
 
-    /// The dataID that contains the actionKey that produces this artifact.
-    LLBDataID actionID = 1;
+    // The dataID that contains the list of actions where the artifact owner action resides. This corresponds to a
+    // dataID that can be used in a RuleEvaluationKeyID to obtain the list of actions.
+    LLBDataID actionsOwner = 1;
 
-    /// The index of the artifact in the list of outputs.
-    int32 outputIndex = 2;
+    // The index of the action in the action list.
+    int32 actionIndex = 2;
+
+    // The index of the artifact in the list of outputs.
+    int32 outputIndex = 3;
 }

--- a/Protos/BuildSystem/Evaluation/rule_evaluation.proto
+++ b/Protos/BuildSystem/Evaluation/rule_evaluation.proto
@@ -10,33 +10,48 @@ syntax = "proto3";
 
 import "BuildSystem/Evaluation/configuration.proto";
 import "BuildSystem/Evaluation/label.proto";
+import "BuildSystem/Evaluation/configured_target.proto";
 import "BuildSystem/Evaluation/evaluated_target.proto";
 import "CASProtocol/data_id.proto";
 
-/// A RuleEvaluationKey represents the evaluation of the rule for a particular configured target. The evaluation of a
-/// rule results in a list of providers which represent the interface that a configured target offers to dependencies.
-/// This is different from EvaluatedTargetKey in that it is a scoped down version of evaluation, since it does not
-/// require the presence of the rootID field, which effectively changes with any change in the workspace. The digest of
-/// a RuleEvaluationKey should be stable to the _contents_ of a configured target. This means that if a source file
-/// changed, it should not invalidate the cache of a RuleEvaluationKey.
+// The reference to a rule evaluation key. This is used for 2 purposes: to avoid having a large rule evaluation key
+// since the configured target might be large in size (potentially avoidable with proper CAS architecture) and to use
+// as a reference for artifact ownership. Artifacts then get a reference to the rule evaluation that registered them in
+// order to find the action that generates it. Initially this was solved by uploading the action itself into the CAS and
+// having the artifact ownership point to that, but there was a cycle issue when uploading the action keys as some input
+// artifacts had not been updated yet. With this approach, artifacts get the ownership during action registration,
+// avoiding that particular issue.
+message RuleEvaluationKeyID {
+
+    // The data ID for the rule evaluation key.
+    LLBDataID ruleEvaluationKeyID = 1;
+}
+
+// A RuleEvaluationKey represents the evaluation of the rule for a particular configured target. The evaluation of a
+// rule results in a list of providers which represent the interface that a configured target offers to dependencies.
+// This is different from EvaluatedTargetKey in that it is a scoped down version of evaluation, since it does not
+// require the presence of the rootID field, which effectively changes with any change in the workspace. The digest of
+// a RuleEvaluationKey should be stable to the _contents_ of a configured target. This means that if a source file
+// changed, it should not invalidate the cache of a RuleEvaluationKey.
 message RuleEvaluationKey {
 
-    /// The label for the configured target being evaluated.
+    // The label for the configured target being evaluated.
     Label label = 1;
 
-    /// A dataID representing the contents of a ConfigurationTarget. ConfiguredTargets may be quite large depending on
-    /// the number of dependencies and how providers are used. Instead of using the ConfiguredTargetValue in the key,
-    /// we store the contents in the CAS and retrieve it using this ID.
-    LLBDataID configuredTargetID = 2;
+    // The configured target value to evaluate in the rule.
+    ConfiguredTargetValue configuredTargetValue = 2;
 
     // The configuration key under which this should be evaluated under. The ConfigurationValue fragments will be made
     // available in the rule context.
     ConfigurationKey configurationKey = 3;
 }
 
-/// The result of evaluating a configured target under a rule.
+// The result of evaluating a configured target under a rule.
 message RuleEvaluationValue {
 
-    /// The providers returned by the evaluation of the rule
-    LLBProviderMap providerMap = 1;
+    // The list of IDs that correspond to ActionKeys in the CAS.
+    repeated LLBDataID actionIDs = 1;
+
+    // The providers returned by the evaluation of the rule
+    LLBProviderMap providerMap = 2;
 }

--- a/Sources/LLBBuildSystem/FunctionMap.swift
+++ b/Sources/LLBBuildSystem/FunctionMap.swift
@@ -24,7 +24,7 @@ class LLBBuildFunctionMap {
                 configuredTargetDelegate: configuredTargetDelegate
             ),
             EvaluatedTargetKey.identifier: EvaluatedTargetFunction(engineContext: engineContext),
-            RuleEvaluationKey.identifier: RuleEvaluationFunction(
+            RuleEvaluationKeyID.identifier: RuleEvaluationFunction(
                 engineContext: engineContext,
                 ruleLookupDelegate: ruleLookupDelegate
             ),

--- a/Sources/LLBBuildSystem/Functions/Execution/Action.swift
+++ b/Sources/LLBBuildSystem/Functions/Execution/Action.swift
@@ -11,7 +11,6 @@ import LLBCAS
 import LLBBuildSystemProtocol
 
 extension ActionKey: LLBBuildKey {}
-
 extension ActionValue: LLBBuildValue {}
 
 /// Convenience initializer.

--- a/Sources/LLBBuildSystem/Generated/BuildSystem/Evaluation/artifact_owner.pb.swift
+++ b/Sources/LLBBuildSystem/Generated/BuildSystem/Evaluation/artifact_owner.pb.swift
@@ -30,64 +30,165 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-//// An ArtifactOwner contains the reference to the action that generates an artifact, effectively providing the link
-//// between artifacts and actions that make up the action graph.
+public struct ArtifactOwnerKey {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var artifactOwnerID: LLBCAS.LLBDataID {
+    get {return _artifactOwnerID ?? LLBCAS.LLBDataID()}
+    set {_artifactOwnerID = newValue}
+  }
+  /// Returns true if `artifactOwnerID` has been explicitly set.
+  public var hasArtifactOwnerID: Bool {return self._artifactOwnerID != nil}
+  /// Clears the value of `artifactOwnerID`. Subsequent reads from it will return its default value.
+  public mutating func clearArtifactOwnerID() {self._artifactOwnerID = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _artifactOwnerID: LLBCAS.LLBDataID? = nil
+}
+
+public struct ArtifactOwnerValue {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var actionIds: [LLBCAS.LLBDataID] = []
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// An ArtifactOwner contains the reference to the action that generates an artifact, effectively providing the link
+/// between artifacts and actions that make up the action graph.
 public struct LLBArtifactOwner {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  //// The dataID that contains the actionKey that produces this artifact.
-  public var actionID: LLBCAS.LLBDataID {
-    get {return _actionID ?? LLBCAS.LLBDataID()}
-    set {_actionID = newValue}
+  /// The dataID that contains the list of actions where the artifact owner action resides. This corresponds to a
+  /// dataID that can be used in a RuleEvaluationKeyID to obtain the list of actions.
+  public var actionsOwner: LLBCAS.LLBDataID {
+    get {return _actionsOwner ?? LLBCAS.LLBDataID()}
+    set {_actionsOwner = newValue}
   }
-  /// Returns true if `actionID` has been explicitly set.
-  public var hasActionID: Bool {return self._actionID != nil}
-  /// Clears the value of `actionID`. Subsequent reads from it will return its default value.
-  public mutating func clearActionID() {self._actionID = nil}
+  /// Returns true if `actionsOwner` has been explicitly set.
+  public var hasActionsOwner: Bool {return self._actionsOwner != nil}
+  /// Clears the value of `actionsOwner`. Subsequent reads from it will return its default value.
+  public mutating func clearActionsOwner() {self._actionsOwner = nil}
 
-  //// The index of the artifact in the list of outputs.
+  /// The index of the action in the action list.
+  public var actionIndex: Int32 = 0
+
+  /// The index of the artifact in the list of outputs.
   public var outputIndex: Int32 = 0
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
-  fileprivate var _actionID: LLBCAS.LLBDataID? = nil
+  fileprivate var _actionsOwner: LLBCAS.LLBDataID? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-extension LLBArtifactOwner: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = "LLBArtifactOwner"
+extension ArtifactOwnerKey: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = "ArtifactOwnerKey"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "actionID"),
-    2: .same(proto: "outputIndex"),
+    1: .same(proto: "artifactOwnerID"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       switch fieldNumber {
-      case 1: try decoder.decodeSingularMessageField(value: &self._actionID)
-      case 2: try decoder.decodeSingularInt32Field(value: &self.outputIndex)
+      case 1: try decoder.decodeSingularMessageField(value: &self._artifactOwnerID)
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._actionID {
+    if let v = self._artifactOwnerID {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
     }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: ArtifactOwnerKey, rhs: ArtifactOwnerKey) -> Bool {
+    if lhs._artifactOwnerID != rhs._artifactOwnerID {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension ArtifactOwnerValue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = "ArtifactOwnerValue"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "actionIDs"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeRepeatedMessageField(value: &self.actionIds)
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.actionIds.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.actionIds, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: ArtifactOwnerValue, rhs: ArtifactOwnerValue) -> Bool {
+    if lhs.actionIds != rhs.actionIds {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension LLBArtifactOwner: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = "LLBArtifactOwner"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "actionsOwner"),
+    2: .same(proto: "actionIndex"),
+    3: .same(proto: "outputIndex"),
+  ]
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      switch fieldNumber {
+      case 1: try decoder.decodeSingularMessageField(value: &self._actionsOwner)
+      case 2: try decoder.decodeSingularInt32Field(value: &self.actionIndex)
+      case 3: try decoder.decodeSingularInt32Field(value: &self.outputIndex)
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if let v = self._actionsOwner {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    }
+    if self.actionIndex != 0 {
+      try visitor.visitSingularInt32Field(value: self.actionIndex, fieldNumber: 2)
+    }
     if self.outputIndex != 0 {
-      try visitor.visitSingularInt32Field(value: self.outputIndex, fieldNumber: 2)
+      try visitor.visitSingularInt32Field(value: self.outputIndex, fieldNumber: 3)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: LLBArtifactOwner, rhs: LLBArtifactOwner) -> Bool {
-    if lhs._actionID != rhs._actionID {return false}
+    if lhs._actionsOwner != rhs._actionsOwner {return false}
+    if lhs.actionIndex != rhs.actionIndex {return false}
     if lhs.outputIndex != rhs.outputIndex {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true


### PR DESCRIPTION
This change ensures that static writes happen before action serialization, so that the artifacts have a chance to be updated before they're serialized.

Also, moves the actions into the value for rule evaluation, since that has a stable key during the evaluation of the function and should be cached at the moment the artifacts expand them