### PR TITLE
Refactor engine key usage

### DIFF
--- a/Examples/GameOfLife/Sources/GameOfLife/Configuration/Configuration.swift
+++ b/Examples/GameOfLife/Sources/GameOfLife/Configuration/Configuration.swift
@@ -11,7 +11,7 @@ import Foundation
 import llbuild2
 
 /// A simple structure containing the initial state for the board at generation 0.
-struct InitialBoard: Codable {
+struct InitialBoard: Codable, Hashable {
     let points: [Point]
 
     func isAlive(_ point: Point) -> Bool {
@@ -22,7 +22,7 @@ struct InitialBoard: Codable {
 /// The configuration key represents the minimum amount of data needed to construct a full configuration fragment. For
 /// GameOfLife purpose, we just need to store the initial board state and the size of the board. All cell and board targets
 /// at any generation derived from to this initial state.
-struct GameOfLifeConfigurationKey: LLBConfigurationFragmentKey, Codable {
+struct GameOfLifeConfigurationKey: LLBConfigurationFragmentKey, Codable, Hashable {
     static let identifier = String(describing: Self.self)
 
     let initialBoard: InitialBoard

--- a/Examples/GameOfLife/Sources/GameOfLife/Functions/Generation.swift
+++ b/Examples/GameOfLife/Sources/GameOfLife/Functions/Generation.swift
@@ -11,7 +11,7 @@ import LLBBuildSystem
 
 /// GenerationKey represents the request for a board at a particular generation for a given board size and initial
 /// state.
-struct GenerationKey: LLBBuildKey, Codable {
+struct GenerationKey: LLBBuildKey, Codable, Hashable {
     let initialBoard: InitialBoard
     let size: Point
     let generation: Int

--- a/Sources/LLBBuildSystem/Functions/Execution/ActionID.swift
+++ b/Sources/LLBBuildSystem/Functions/Execution/ActionID.swift
@@ -19,7 +19,7 @@ extension LLBActionKey: LLBBuildValue {}
 /// and deserialization of previously deserialized instances of the same action are shared. Without this, each
 /// ArtifactFunction invocation would have to deserialize the ActionKey, which is potentially a problem for actions that
 /// have many declared outputs.
-struct ActionIDKey: LLBBuildKey {
+struct ActionIDKey: LLBBuildKey, Hashable {
     public static let identifier = "ActionIDKey"
 
     /// The data ID representing the serialized form of an ActionKey.

--- a/Sources/LLBSupport/Futures/EventualResultsCache.swift
+++ b/Sources/LLBSupport/Futures/EventualResultsCache.swift
@@ -1,0 +1,39 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+/// Cache of keys to eventually obtainable values.
+///
+/// This cache coalesces requests and avoids re-obtaining values multiple times.
+public final class LLBEventualResultsCache<Key: Hashable, Value>: LLBFutureDeduplicator<Key, Value> {
+    /// The already cached keys.
+    @usableFromInline
+    internal var storage = [Key: LLBFuture<Value>]()
+
+    /// Return the number of entries in the cache.
+    @inlinable
+    public var count: Int {
+        get { return lock.withLock { storage.count } }
+    }
+
+    @inlinable
+    override internal func lockedCacheGet(key: Key) -> LLBFuture<Value>? {
+        return storage[key]
+    }
+
+    @inlinable
+    override internal func lockedCacheSet(_ key: Key, _ future: LLBFuture<Value>) {
+        storage[key] = future
+    }
+
+    @inlinable
+    public override subscript(_ key: Key) -> LLBFuture<Value>? {
+        get { return super[key] }
+        set { lock.withLockVoid { storage[key] = newValue } }
+    }
+}

--- a/Sources/LLBSupport/Futures/FutureDeduplicator.swift
+++ b/Sources/LLBSupport/Futures/FutureDeduplicator.swift
@@ -1,0 +1,151 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import Dispatch
+
+import NIOConcurrencyHelpers
+
+
+/// Deduplicate results of multiple requests for the same value.
+///
+/// This cache coalesces requests and avoids re-obtaining values multiple times.
+public class LLBFutureDeduplicator<Key: Hashable, Value> {
+    /// The futures group.
+    @usableFromInline
+    internal let group: LLBFuturesDispatchGroup
+
+    /// When to expire results that couldn't be resolved in time.
+    @usableFromInline
+    internal let partialResultExpiration: DispatchTimeInterval
+
+    /// Protect shared inFlightRequests.
+    @usableFromInline
+    internal let lock = NIOConcurrencyHelpers.Lock()
+
+    /// The mapping of the keys currently being resolved.
+    @usableFromInline
+    internal var inFlightRequests = [Key: (result: LLBPromise<Value>, expires: DispatchTime)]()
+
+    /// Override expiration of erroneous result by the error type.
+    /// By default erroneous results expire immediately.
+    @usableFromInline
+    internal var expirationInterval: (_ for: Swift.Error) -> DispatchTimeInterval?
+
+    /// Return the number of entries in the cache.
+    public var inFlightRequestCount: Int {
+        get { return lock.withLock { inFlightRequests.count } }
+    }
+
+    public init(group: LLBFuturesDispatchGroup, partialResultExpiration: DispatchTimeInterval = .seconds(300), expirationIntervalOverride: @escaping (_ for: Swift.Error) -> DispatchTimeInterval? = { _ in nil }) {
+        self.group = group
+        self.partialResultExpiration = partialResultExpiration
+        self.expirationInterval = expirationIntervalOverride
+    }
+
+    /// Debug expiration time.
+    public func getExpiration(for key: Key) -> DispatchTime? {
+        return lock.withLock { inFlightRequests[key]?.expires }
+    }
+
+    // Check if we already have this value, under lock.
+    @inlinable
+    internal func lockedCacheGet(key: Key) -> LLBFuture<Value>? {
+        // Override if needed.
+        return nil
+    }
+
+    // Cache the value, under lock.
+    @inlinable
+    internal func lockedCacheSet(_ key: Key, _ future: LLBFuture<Value>) {
+        // Override if needed.
+    }
+
+    /// Opportunistically extract in-flight future to possibly piggy back on
+    /// an existing future that is going on without initiating a new value
+    /// resolution.
+    /// - Returns:
+    ///     `nil` if the value future doesn't exist in flight.
+    ///     _future_,  if the value is being computed.
+    @inlinable
+    public subscript(_ key: Key) -> LLBFuture<Value>? {
+        get {
+            let now = DispatchTime.now()
+            return lock.withLock {
+                if let valueFuture = lockedCacheGet(key: key) {
+                    return valueFuture
+                }
+                guard let (valuePromise, expires) = inFlightRequests[key] else {
+                    return nil
+                }
+                guard now < expires else {
+                    inFlightRequests[key] = nil
+                    return nil
+                }
+                return valuePromise.futureResult
+            }
+        }
+    }
+
+    @inlinable
+    public func value(for key: Key, with resolver: (Key) -> LLBFuture<Value>) -> LLBFuture<Value> {
+        let now = DispatchTime.now()
+
+        let (future, createdPromise): (LLBFuture<Value>, LLBPromise<Value>?) = lock.withLock {
+            if let valueFuture = lockedCacheGet(key: key) {
+                return (valueFuture, nil)
+            }
+
+            if let (valuePromise, expires) = inFlightRequests[key] {
+                guard expires < now else {
+                    return (valuePromise.futureResult, nil)
+                }
+            }
+
+            // Stop deduplicating requests after a long-ish timeout,
+            // just in case there is a particularly long CAS lag.
+            let expires = now + partialResultExpiration
+
+            // Cache for future use.
+            let promise = self.group.next().makePromise(of: Value.self)
+            self.inFlightRequests[key] = (promise, expires)
+            return (promise.futureResult, promise)
+        }
+
+        // If the promise was not created, return whatever's in the future.
+        guard let promise = createdPromise else {
+            return future
+        }
+
+        resolver(key).map { result in
+            self.lock.withLockVoid {
+                guard self.inFlightRequests[key]?.result.futureResult === future else {
+                    return
+                }
+                // Resolved, done.
+                self.inFlightRequests[key] = nil
+                self.lockedCacheSet(key, future)
+            }
+            return result
+        }.flatMapErrorThrowing { error in
+            let expires: DispatchTimeInterval? = self.expirationInterval(error)
+            self.lock.withLockVoid {
+                guard self.inFlightRequests[key]?.result.futureResult === future else {
+                    return
+                }
+                if let interval = expires {
+                    self.inFlightRequests[key] = (promise, now + interval)
+                } else {
+                    self.inFlightRequests[key] = nil
+                }
+            }
+            throw error
+        }.cascade(to: promise)
+
+        return promise.futureResult
+    }
+}

--- a/Sources/llbuild2/Core/KeyDependencyGraph.swift
+++ b/Sources/llbuild2/Core/KeyDependencyGraph.swift
@@ -38,8 +38,8 @@ public class LLBKeyDependencyGraph {
     public func addEdge(from origin: LLBKey, to destination: LLBKey) throws {
         // This is the biggest expense in this method. We need to find a way to identify keys in a faster way than
         // serializing and hashing.
-        let originID = origin.digest.hashValue
-        let destinationID = destination.digest.hashValue
+        let originID = origin.hashValue
+        let destinationID = destination.hashValue
 
         // Check if the direct dependency is already known, in which case, skip the check since the edge is already
         // been proven to not have a cycle.

--- a/Tests/LLBBuildSystemTests/BuildEngineTests.swift
+++ b/Tests/LLBBuildSystemTests/BuildEngineTests.swift
@@ -15,7 +15,7 @@ import LLBUtil
 import XCTest
 
 /// Key requesting the addition of some numbers. In order to maximize cacheability, the numbers should be sorted.
-struct SumKey: LLBBuildKey, Codable {
+struct SumKey: LLBBuildKey, Codable, Hashable {
     static let identifier = String(describing: Self.self)
 
     let numbers: [Int]

--- a/Tests/LLBBuildSystemTests/ConfigurationTests.swift
+++ b/Tests/LLBBuildSystemTests/ConfigurationTests.swift
@@ -14,7 +14,7 @@ import LLBCASFileTree
 import TSCBasic
 import XCTest
 
-struct PlatformFragmentKey: LLBConfigurationFragmentKey, Codable {
+struct PlatformFragmentKey: LLBConfigurationFragmentKey, Codable, Hashable {
     static let identifier = String(describing: Self.self)
 
     let platformName: String


### PR DESCRIPTION
- Make LLBKey essentially 'Hashable'
- Remove SHA256 digest usage in LLBKey
- Refactor engine to sit on top of EventualResultsCache