### PR TITLE
Add LLBTypedCachedFunction implementation to engine core

### DIFF
--- a/Sources/LLBBuildSystem/BuildKey.swift
+++ b/Sources/LLBBuildSystem/BuildKey.swift
@@ -17,7 +17,7 @@ public protocol LLBBuildKey: LLBKey {
 }
 
 /// Convenience protocol for referencing build system specific values.
-public protocol LLBBuildValue: LLBValue, LLBPolymorphicSerializable {}
+public protocol LLBBuildValue: LLBValue, LLBSerializable {}
 
 /// Identifier type for each type of build system specific key.
 public typealias LLBBuildKeyIdentifier = String

--- a/Sources/LLBBuildSystem/Function.swift
+++ b/Sources/LLBBuildSystem/Function.swift
@@ -8,27 +8,17 @@
 
 import llbuild2
 
-public enum LLBBuildFunctionError: Error {
-    case unexpectedKeyType(String)
-}
-
 /// An "abstract" class that represents a build function, which includes the engineContext reference and a way to
 /// statically specify the types of the build keys and values.
-open class LLBBuildFunction<K: LLBBuildKey, V: LLBBuildValue>: LLBFunction {
+open class LLBBuildFunction<K: LLBBuildKey, V: LLBBuildValue>: LLBTypedCachingFunction<K, V> {
     public let engineContext: LLBBuildEngineContext
 
     public init(engineContext: LLBBuildEngineContext) {
         self.engineContext = engineContext
     }
 
-    public final func compute(key: LLBKey, _ fi: LLBFunctionInterface) -> LLBFuture<LLBValue> {
-        if let key = key as? K {
-            return evaluate(key: key, LLBBuildFunctionInterface(fi: fi)).map { $0 }
-        } else {
-            return engineContext.group.next().makeFailedFuture(
-                LLBBuildFunctionError.unexpectedKeyType("Expected type \(String(describing: K.self)), but got \(String(describing: type(of: key)))")
-            )
-        }
+    override open func compute(key: K, _ fi: LLBFunctionInterface) -> LLBFuture<V> {
+        return evaluate(key: key, LLBBuildFunctionInterface(fi: fi)).map { $0 }
     }
 
     /// Subclasses of LLBBuildFunction should override this method to provide the actual implementation of the function.

--- a/Sources/LLBBuildSystem/Functions/Evaluation/Configuration.swift
+++ b/Sources/LLBBuildSystem/Functions/Evaluation/Configuration.swift
@@ -13,7 +13,7 @@ extension LLBConfigurationKey: LLBBuildKey {}
 extension LLBConfigurationValue: LLBBuildValue {}
 
 public protocol LLBConfigurationFragmentKey: LLBBuildKey, LLBPolymorphicSerializable {}
-public protocol LLBConfigurationFragment: LLBBuildValue {}
+public protocol LLBConfigurationFragment: LLBBuildValue, LLBPolymorphicSerializable {}
 
 public enum LLBConfigurationError: Error {
     /// Unexpected type when deserializing the configured target

--- a/Sources/llbuild2/EngineProtocol/AnySerializable.swift
+++ b/Sources/llbuild2/EngineProtocol/AnySerializable.swift
@@ -105,6 +105,12 @@ extension LLBCASObjectRepresentable where Self: LLBPolymorphicSerializable {
     }
 }
 
+extension LLBCASObjectRepresentable where Self: LLBSerializable {
+    public func asCASObject() throws -> LLBCASObject {
+        return LLBCASObject(refs: [], data: try self.toBytes())
+    }
+}
+
 extension LLBAnySerializable {
     public init(from casObject: LLBCASObject) throws {
         self = try LLBAnySerializable.init(from: casObject.data)


### PR DESCRIPTION
This allows clients of llbuild2 to decide whether they want to use the raw function APIs or a more elaborate API that allows for caching of previously computed keys from a database.