### PR TITLE
[Rules] Add global context in rule context

### DIFF
--- a/Sources/LLBBuildSystem/Functions/Evaluation/RuleEvaluation.swift
+++ b/Sources/LLBBuildSystem/Functions/Evaluation/RuleEvaluation.swift
@@ -88,7 +88,7 @@ final class RuleEvaluationFunction: LLBBuildFunction<LLBRuleEvaluationKeyID, LLB
             }
 
             let ruleContext = LLBRuleContext(
-                group: ctx.group,
+                ctx: ctx,
                 label: ruleEvaluationKey.label,
                 configurationValue: configurationValue,
                 artifactOwnerID: key.ruleEvaluationKeyID,

--- a/Sources/LLBBuildSystem/Rules/RuleContext.swift
+++ b/Sources/LLBBuildSystem/Rules/RuleContext.swift
@@ -41,7 +41,10 @@ fileprivate enum RuleContextTargetDependencyType {
 }
 
 public class LLBRuleContext {
-    public let group: LLBFuturesDispatchGroup
+    /// The shared context.
+    public let ctx: Context
+
+    public var group: LLBFuturesDispatchGroup { ctx.group }
 
     /// The label for the target being evaluated.
     public let label: LLBLabel
@@ -74,12 +77,12 @@ public class LLBRuleContext {
     private let artifactRoots: [String]
 
     init(
-        group: LLBFuturesDispatchGroup,
+        ctx: Context,
         label: LLBLabel,
         configurationValue: LLBConfigurationValue,
         artifactOwnerID: LLBDataID,
         targetDependencies: [LLBNamedConfiguredTargetDependency]) {
-        self.group = group
+        self.ctx = ctx
         self.label = label
         self.configurationValue = configurationValue
         self.artifactOwnerID = artifactOwnerID


### PR DESCRIPTION
Useful for clients to plumb additional context during rule construction.