### PR TITLE
Use separate coder instances

### DIFF
--- a/Sources/llbuild2fx/Key.swift
+++ b/Sources/llbuild2fx/Key.swift
@@ -43,13 +43,6 @@ final class InternalKey<K: FXKey> {
     }
 }
 
-private let LongKeyEncoder: JSONEncoder = {
-    let encoder = JSONEncoder()
-    encoder.dateEncodingStrategy = .iso8601
-    encoder.outputFormatting = [.sortedKeys]
-    return encoder
-}()
-
 extension InternalKey: FXKeyProperties {
     var volatile: Bool {
         K.volatile
@@ -67,7 +60,7 @@ extension InternalKey: FXKeyProperties {
             return [basePath, argsKey].joined(separator: "/")
         }
 
-        let json = try! LongKeyEncoder.encode(key)
+        let json = try! FXEncoder().encode(key)
         guard json.count > keyLengthLimit else {
             return [basePath, String(data: json, encoding: .utf8)!].joined(separator: "/")
         }

--- a/Sources/llbuild2fx/Value.swift
+++ b/Sources/llbuild2fx/Value.swift
@@ -107,7 +107,7 @@ extension Array: FXValue where Element: FXValue {
 
 extension FXValue /* LLBCASObjectRepresentable */ {
     public func asCASObject() throws -> LLBCASObject {
-        let data = try FXEncoder.encode(codableValue)
+        let data = try FXEncoder().encode(codableValue)
         let buffer = LLBByteBufferAllocator().buffer(bytes: ArraySlice<UInt8>(data))
         return LLBCASObject(refs: refs, data: buffer)
     }
@@ -116,7 +116,7 @@ extension FXValue /* LLBCASObjectRepresentable */ {
 extension FXValue /* LLBCASObjectConstructable */ {
     public init(from casObject: LLBCASObject) throws {
         let data = Data(casObject.data.readableBytesView)
-        let codable = try FXDecoder.decode(CodableValueType.self, from: data)
+        let codable = try FXDecoder().decode(CodableValueType.self, from: data)
 
         self = try Self(refs: casObject.refs, codableValue: codable)
     }
@@ -142,7 +142,7 @@ private final class CodableInternalValue<V: FXValue>: Codable {
 extension InternalValue: LLBCASObjectRepresentable {
     func asCASObject() throws -> LLBCASObject {
         let codable = CodableInternalValue(value)
-        let data = try FXEncoder.encode(codable)
+        let data = try FXEncoder().encode(codable)
         let buffer = LLBByteBufferAllocator().buffer(bytes: ArraySlice<UInt8>(data))
         return LLBCASObject(refs: value.refs, data: buffer)
     }
@@ -151,7 +151,7 @@ extension InternalValue: LLBCASObjectRepresentable {
 extension InternalValue: LLBCASObjectConstructable {
     convenience init(from casObject: LLBCASObject) throws {
         let data = Data(casObject.data.readableBytesView)
-        let codable = try FXDecoder.decode(CodableInternalValue<V>.self, from: data)
+        let codable = try FXDecoder().decode(CodableInternalValue<V>.self, from: data)
         let value = try V(refs: casObject.refs, codableValue: codable.value)
         self.init(value)
     }

--- a/Sources/llbuild2fx/WrappedDataID.swift
+++ b/Sources/llbuild2fx/WrappedDataID.swift
@@ -35,12 +35,7 @@ extension FXSingleDataIDValue {
 
 extension FXSingleDataIDValue {
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-
-        let hash = LLBDataID(blake3hash: ArraySlice<UInt8>(dataID.bytes))
-        // We don't need the whole ID to avoid key collisions.
-        let str = ArraySlice(hash.bytes.dropFirst().prefix(9)).base64URL()
-        try container.encode(str)
+        try encoder.encodeHash(of: ArraySlice<UInt8>(dataID.bytes))
     }
 }
 


### PR DESCRIPTION
Rather than publishing non-threadsafe coder instances, allocate new coders as needed, and only publish the hashing function needed for key definitions.