### PR TITLE
Ensure errors have stable names

### DIFF
--- a/Sources/llbuild2fx/Delegate.swift
+++ b/Sources/llbuild2fx/Delegate.swift
@@ -12,11 +12,11 @@ protocol FXFunctionProvider {
     func function() -> LLBFunction
 }
 
-private enum Error: Swift.Error {
-    case noFXFunctionProvider(LLBKey)
-}
-
 struct FXEngineDelegate: LLBEngineDelegate {
+    enum Error: Swift.Error {
+        case noFXFunctionProvider(LLBKey)
+    }
+
     func lookupFunction(forKey key: LLBKey, _ ctx: Context) -> LLBFuture<LLBFunction> {
         guard let functionProvider = key as? FXFunctionProvider else {
             return ctx.group.next().makeFailedFuture(Error.noFXFunctionProvider(key))

--- a/Sources/llbuild2fx/FunctionCache.swift
+++ b/Sources/llbuild2fx/FunctionCache.swift
@@ -10,11 +10,6 @@ import Logging
 import TSCUtility
 import llbuild2
 
-private enum Error: Swift.Error {
-    case notFound
-    case notCachePathProvider(LLBKey)
-}
-
 public protocol FXKeyProperties {
     var volatile: Bool { get }
 
@@ -27,6 +22,10 @@ public protocol FXFunctionCache {
 }
 
 class FXFunctionCacheAdaptor: LLBFunctionCache {
+    enum Error: Swift.Error {
+        case notCachePathProvider(LLBKey)
+    }
+
     private let group: LLBFuturesDispatchGroup
     private let cache: FXFunctionCache
 

--- a/Sources/llbuild2fx/FunctionInterface.swift
+++ b/Sources/llbuild2fx/FunctionInterface.swift
@@ -9,13 +9,12 @@
 import NIOConcurrencyHelpers
 import llbuild2
 
-private enum Error: Swift.Error {
-    case missingRequiredCacheEntry(String)
-    case unexpressedKeyDependency(from: String, to: String)
-    case unexpressedKeyDependent(from: String, to: String)
-}
-
 public final class FXFunctionInterface<K: FXKey> {
+    enum Error: Swift.Error {
+        case missingRequiredCacheEntry(String)
+        case unexpressedKeyDependency(from: String, to: String)
+    }
+
     private let key: K
     private let fi: LLBFunctionInterface
     private var requestedKeyCachePaths = [String]()

--- a/Sources/llbuild2fx/Value.swift
+++ b/Sources/llbuild2fx/Value.swift
@@ -26,10 +26,6 @@ extension FXValue where Self: Codable {
     }
 }
 
-private enum Error: Swift.Error {
-    case unexpectedRefsCount(Int)
-}
-
 public final class CASCodableOptional<T: Codable>: Codable {
     let codableValue: T?
     init(codableValue: T?) {

--- a/Sources/llbuild2fx/WrappedDataID.swift
+++ b/Sources/llbuild2fx/WrappedDataID.swift
@@ -39,7 +39,7 @@ extension FXSingleDataIDValue {
     }
 }
 
-private enum Error: Swift.Error {
+enum WrappedDataIDError: Swift.Error {
     case noRefs
     case wrongNodeType(id: LLBDataID, expected: LLBFileType, actual: LLBFileType)
 }
@@ -48,7 +48,7 @@ extension FXSingleDataIDValue {
     public init(from casObject: LLBCASObject) throws {
         let refs = casObject.refs
         guard !refs.isEmpty else {
-            throw Error.noRefs
+            throw WrappedDataIDError.noRefs
         }
 
         let dataID = refs[0]
@@ -85,7 +85,7 @@ extension FXTreeID {
         return client.load(dataID, type: .directory, ctx).flatMapThrowing { node in
             let type = node.type()
             guard type == .directory else {
-                throw Error.wrongNodeType(id: dataID, expected: .directory, actual: type)
+                throw WrappedDataIDError.wrongNodeType(id: dataID, expected: .directory, actual: type)
             }
 
             return node.tree!
@@ -104,7 +104,7 @@ extension FXFileID {
         return client.load(dataID, type: .plainFile, ctx).flatMapThrowing { node in
             let type = node.type()
             guard type == .plainFile else {
-                throw Error.wrongNodeType(id: dataID, expected: .plainFile, actual: type)
+                throw WrappedDataIDError.wrongNodeType(id: dataID, expected: .plainFile, actual: type)
             }
 
             return node.blob!


### PR DESCRIPTION
This avoids errors that print with arbitrary addresses, and removes some unused cases.