### PR TITLE
Rename `runLater` to `runCancellable`

### DIFF
--- a/Sources/llbuild2fx/SpawnProcess.swift
+++ b/Sources/llbuild2fx/SpawnProcess.swift
@@ -32,7 +32,7 @@ extension Foundation.Process {
         }
     }
 
-    fileprivate func runLater(_ ctx: Context) -> LLBCancellableFuture<Void> {
+    fileprivate func runCancellable(_ ctx: Context) -> LLBCancellableFuture<Void> {
         let completionPromise: LLBPromise<Void> = ctx.group.next().makePromise()
 
         self.terminationHandler = { process in
@@ -308,7 +308,7 @@ public struct SpawnProcess {
         inputTree.materialize(ctx) { inputPath in
             withTemporaryDirectory(ctx) { outputPath in
                 let process = spec.process(inputPath: inputPath, outputPath: outputPath)
-                let cancellable = process.runLater(ctx)
+                let cancellable = process.runCancellable(ctx)
 
                 ctx.fxApplyDeadline(cancellable)
 


### PR DESCRIPTION
Re https://github.com/apple/swift-llbuild2/pull/133#discussion_r768118814