### PR TITLE
Publish types required for cache introspection

### DIFF
--- a/Sources/llbuild2fx/Coding.swift
+++ b/Sources/llbuild2fx/Coding.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-struct FXEncoder {
-    func encode<T: Encodable>(_ value: T) throws -> Data {
+public struct FXEncoder {
+    public func encode<T: Encodable>(_ value: T) throws -> Data {
         let encoder = JSONEncoder()
 
         encoder.dateEncodingStrategy = .iso8601
@@ -19,8 +19,8 @@ struct FXEncoder {
     }
 }
 
-struct FXDecoder {
-    func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+public struct FXDecoder {
+    public func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
         let decoder = JSONDecoder()
 
         decoder.dateDecodingStrategy = .iso8601

--- a/Sources/llbuild2fx/FunctionInterface.swift
+++ b/Sources/llbuild2fx/FunctionInterface.swift
@@ -17,9 +17,9 @@ public final class FXFunctionInterface<K: FXKey> {
 
     private let key: K
     private let fi: LLBFunctionInterface
-    private var requestedKeyCachePaths = [String]()
+    private var requestedKeyCachePaths = FXSortedSet<String>()
     private let lock = Lock()
-    var requestedCacheKeyPathsSnapshot: [String] {
+    var requestedCacheKeyPathsSnapshot: FXSortedSet<String> {
         lock.withLock {
             requestedKeyCachePaths
         }
@@ -44,7 +44,7 @@ public final class FXFunctionInterface<K: FXKey> {
             }
 
             lock.withLock {
-                requestedKeyCachePaths += [realX.cachePath]
+                _ = requestedKeyCachePaths.insert(realX.cachePath)
             }
 
             let cacheCheck: LLBFuture<Void>

--- a/Sources/llbuild2fx/Versioning.swift
+++ b/Sources/llbuild2fx/Versioning.swift
@@ -58,7 +58,7 @@ extension FXVersioning {
         return aggregatedVersionDependencies.map { $0.version }.reduce(0, +)
     }
 
-    static var cacheKeyPrefix: String {
+    public static var cacheKeyPrefix: String {
         [
             "\(name)",
             "\(aggregatedVersion)",


### PR DESCRIPTION
To invalidate fine-grained portions of the cache, we need to be able to decode the persisted cache paths.