### PR TITLE
Add stats for tracking in-flight evaluations

### DIFF
--- a/Sources/llbuild2fx/Engine.swift
+++ b/Sources/llbuild2fx/Engine.swift
@@ -16,22 +16,23 @@ public final class FXBuildEngine {
     private let db: LLBCASDatabase
     private let cache: FXFunctionCache?
     private let executor: FXExecutor
+    private let stats: FXBuildEngineStats
     private let logger: Logger?
-
 
     public init(
         group: LLBFuturesDispatchGroup,
         db: LLBCASDatabase,
         functionCache: FXFunctionCache?,
         executor: FXExecutor,
+        stats: FXBuildEngineStats? = nil,
         logger: Logger? = nil
     ) {
         self.group = group
         self.db = db
         self.cache = functionCache
         self.executor = executor
+        self.stats = stats ?? .init()
         self.logger = logger
-
     }
 
     private var engine: LLBEngine {
@@ -54,7 +55,10 @@ public final class FXBuildEngine {
 
     private func engineContext(_ ctx: Context) -> Context {
         var ctx = ctx
+
         ctx.fxExecutor = executor
+        ctx.fxBuildEngineStats = stats
+
         if let logger = self.logger {
             ctx.logger = logger
         }

--- a/Sources/llbuild2fx/Executor.swift
+++ b/Sources/llbuild2fx/Executor.swift
@@ -20,7 +20,7 @@ public protocol FXExecutor {
 private class ContextFXExecutor {}
 
 extension Context {
-    public var fxExecutor: FXExecutor! {
+    var fxExecutor: FXExecutor! {
         get {
             guard let value = self[ObjectIdentifier(ContextFXExecutor.self)] as? FXExecutor else {
                 return nil

--- a/Sources/llbuild2fx/Stats.swift
+++ b/Sources/llbuild2fx/Stats.swift
@@ -1,0 +1,80 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import NIOConcurrencyHelpers
+import TSCUtility
+
+public struct FXBuildEngineStatsSnapshot {
+    public let currentKeys: [String: Int]
+    public let totalKeys: [String: Int]
+    public let currentActions: [String: Int]
+    public let totalActions: [String: Int]
+}
+
+public final class FXBuildEngineStats {
+    private let lock = Lock()
+
+    private var currentKeyCounts: [String: Int] = [:]
+    private var totalKeyCounts: [String: Int] = [:]
+    private var currentActionCounts: [String: Int] = [:]
+    private var totalActionCounts: [String: Int] = [:]
+
+    public init() {}
+
+    public var snapshot: FXBuildEngineStatsSnapshot {
+        lock.withLock {
+            FXBuildEngineStatsSnapshot(
+                currentKeys: currentKeyCounts.filter { $0.1 > 0 },
+                totalKeys: totalKeyCounts.filter { $0.1 > 0 },
+                currentActions: currentActionCounts.filter { $0.1 > 0 },
+                totalActions: totalActionCounts.filter { $0.1 > 0 }
+            )
+        }
+    }
+
+    func add(key: String) {
+        lock.withLock {
+            currentKeyCounts[key] = (currentKeyCounts[key] ?? 0) + 1
+            totalKeyCounts[key] = (totalKeyCounts[key] ?? 0) + 1
+        }
+    }
+
+    func remove(key: String) {
+        lock.withLock {
+            currentKeyCounts[key] = currentKeyCounts[key]! - 1
+        }
+    }
+
+    func add(action: String) {
+        lock.withLock {
+            currentActionCounts[action] = (currentActionCounts[action] ?? 0) + 1
+            totalActionCounts[action] = (totalActionCounts[action] ?? 0) + 1
+        }
+    }
+
+    func remove(action: String) {
+        lock.withLock {
+            currentActionCounts[action] = currentActionCounts[action]! - 1
+        }
+    }
+}
+
+extension Context {
+    var fxBuildEngineStats: FXBuildEngineStats! {
+        get {
+            guard let stats = self[ObjectIdentifier(FXBuildEngineStats.self)] as? FXBuildEngineStats else {
+                return nil
+            }
+
+            return stats
+        }
+        set {
+            self[ObjectIdentifier(FXBuildEngineStats.self)] = newValue
+        }
+    }
+}

--- a/Tests/llbuild2fxTests/EngineTests.swift
+++ b/Tests/llbuild2fxTests/EngineTests.swift
@@ -88,7 +88,7 @@ public struct Sum: FXKey {
     public func computeValue(_ fi: FXFunctionInterface<Self>, _ ctx: Context) -> LLBFuture<SumAction.ValueType> {
         let action = SumAction(SumInput(values: self.values))
         let exe = fi.request(FakeExecutable(name: "sum-task"), ctx)
-        return ctx.fxExecutor.perform(action: action, with: exe, ctx)
+        return fi.execute(action: action, with: exe, ctx)
     }
 }
 


### PR DESCRIPTION
This also removes `public` access to the `Context`'s `FXExecutor`, instead funneling through the `FXFunctionInterface` to do the bookkeeping.