### PR TITLE
Move key stats to wrap `compute()` instead of `request()`

### DIFF
--- a/Sources/llbuild2fx/FunctionInterface.swift
+++ b/Sources/llbuild2fx/FunctionInterface.swift
@@ -31,16 +31,6 @@ public final class FXFunctionInterface<K: FXKey> {
     }
 
     public func request<X: FXKey>(_ x: X, requireCacheHit: Bool = false, _ ctx: Context) -> LLBFuture<X.ValueType> {
-        let keyName = String(describing: X.self)
-
-        ctx.fxBuildEngineStats.add(key: keyName)
-
-        return reallyRequest(x, requireCacheHit: requireCacheHit, ctx).always { _ in
-            ctx.fxBuildEngineStats.remove(key: keyName)
-        }
-    }
-
-    private func reallyRequest<X: FXKey>(_ x: X, requireCacheHit: Bool, _ ctx: Context) -> LLBFuture<X.ValueType> {
         do {
             let kDesc = key.internalKey.logDescription()
             let realX = x.internalKey

--- a/Sources/llbuild2fx/Key.swift
+++ b/Sources/llbuild2fx/Key.swift
@@ -116,6 +116,9 @@ private final class FXFunction<K: FXKey>: LLBTypedCachingFunction<InternalKey<K>
         InternalValue<K.ValueType>
     > {
         let actualKey = key.key
+
+        ctx.fxBuildEngineStats.add(key: key.name)
+
         let fxfi = FXFunctionInterface(actualKey, fi)
         return actualKey.computeValue(fxfi, ctx).flatMapError { underlyingError in
             let augmentedError: Swift.Error
@@ -138,7 +141,9 @@ private final class FXFunction<K: FXKey>: LLBTypedCachingFunction<InternalKey<K>
 
             return ctx.group.next().makeFailedFuture(augmentedError)
         }.map { value in
-            return InternalValue(value, requestedCacheKeyPaths: fxfi.requestedCacheKeyPathsSnapshot)
+            InternalValue(value, requestedCacheKeyPaths: fxfi.requestedCacheKeyPathsSnapshot)
+        }.always { _ in
+            ctx.fxBuildEngineStats.remove(key: key.name)
         }
     }
 }


### PR DESCRIPTION
This means we'll also get stats for top-level keys, not just requested keys.