### PR TITLE
Make `LLBEngine`'s delegate weak

### DIFF
--- a/Sources/llbuild2/Core/Engine.swift
+++ b/Sources/llbuild2/Core/Engine.swift
@@ -163,7 +163,7 @@ open class LLBTypedCachingFunction<K: LLBKey, V: LLBValue>: LLBFunction {
     }
 }
 
-public protocol LLBEngineDelegate {
+public protocol LLBEngineDelegate: AnyObject {
     func registerTypes(registry: LLBSerializableRegistry)
     func lookupFunction(forKey: LLBKey, _ ctx: Context) -> LLBFuture<LLBFunction>
 }
@@ -196,7 +196,7 @@ extension Key: Hashable {
 
 public class LLBEngine {
     private let group: LLBFuturesDispatchGroup
-    private let delegate: LLBEngineDelegate
+    private weak var delegate: LLBEngineDelegate!
     private let db: LLBCASDatabase
     fileprivate let executor: LLBExecutor
     fileprivate let pendingResults: LLBEventualResultsCache<Key, LLBValue>

--- a/Sources/llbuild2fx/Delegate.swift
+++ b/Sources/llbuild2fx/Delegate.swift
@@ -12,7 +12,7 @@ protocol FXFunctionProvider {
     func function() -> LLBFunction
 }
 
-struct FXEngineDelegate: LLBEngineDelegate {
+class FXEngineDelegate: LLBEngineDelegate {
     enum Error: Swift.Error {
         case noFXFunctionProvider(LLBKey)
     }

--- a/Sources/llbuild2fx/Engine.swift
+++ b/Sources/llbuild2fx/Engine.swift
@@ -18,6 +18,7 @@ public final class FXBuildEngine {
     private let executor: FXExecutor
     private let stats: FXBuildEngineStats
     private let logger: Logger?
+    private let delegate = FXEngineDelegate()
 
     public init(
         group: LLBFuturesDispatchGroup,
@@ -36,8 +37,6 @@ public final class FXBuildEngine {
     }
 
     private var engine: LLBEngine {
-        let delegate = FXEngineDelegate()
-
         let functionCache: LLBFunctionCache?
         if let cache = self.cache {
             functionCache = FXFunctionCacheAdaptor(group: group, cache: cache)


### PR DESCRIPTION
`LLBEngine`'s delegate was strong, but the delegate might in turn hold a strong reference to the engine, which would create a cycle.