### PR TITLE
Publish `withTemporaryDirectory()`

### DIFF
--- a/Sources/llbuild2fx/TreeMaterialization.swift
+++ b/Sources/llbuild2fx/TreeMaterialization.swift
@@ -31,7 +31,7 @@ extension Context {
     }
 }
 
-func withTemporaryDirectory<R>(_ ctx: Context, _ body: (AbsolutePath) -> LLBFuture<R>) -> LLBFuture<R> {
+public func withTemporaryDirectory<R>(_ ctx: Context, _ body: (AbsolutePath) -> LLBFuture<R>) -> LLBFuture<R> {
     do {
         return try withTemporaryDirectory(removeTreeOnDeinit: false) { path in
             body(path).always { _ in


### PR DESCRIPTION
This is more generally useful than just in the implementation of `TreeMaterialization`.