### PR TITLE
Avoid crash when converting distant future date

### DIFF
--- a/Sources/llbuild2fx/Deadline.swift
+++ b/Sources/llbuild2fx/Deadline.swift
@@ -28,6 +28,10 @@ extension Context {
             return nil
         }
 
+        guard foundationDeadline != .distantFuture else {
+            return nil
+        }
+
         let then = NIODeadline.now()
         let now = Date()
         let timeLeft: TimeInterval = foundationDeadline.timeIntervalSince(now)

--- a/Tests/llbuild2fxTests/DeadlineTests.swift
+++ b/Tests/llbuild2fxTests/DeadlineTests.swift
@@ -1,0 +1,15 @@
+import Foundation
+import TSCUtility
+import XCTest
+import llbuild2fx
+
+final class DeadlineTests: XCTestCase {
+    func testDistantFutureDeadlineIsNil() {
+        var ctx = Context()
+        ctx.fxDeadline = Date.distantFuture
+
+        let deadline = ctx.nioDeadline
+
+        XCTAssertNil(deadline)
+    }
+}


### PR DESCRIPTION
This avoids

~~~~
Fatal error: Double value cannot be converted to Int64 because the result would be greater than Int64.max
~~~~