### PR TITLE
FX performance improvements

### DIFF
--- a/Sources/llbuild2fx/FunctionInterface.swift
+++ b/Sources/llbuild2fx/FunctionInterface.swift
@@ -32,16 +32,14 @@ public final class FXFunctionInterface<K: FXKey> {
 
     public func request<X: FXKey>(_ x: X, requireCacheHit: Bool = false, _ ctx: Context) -> LLBFuture<X.ValueType> {
         do {
-            let kDesc = key.internalKey.logDescription()
             let realX = x.internalKey
-            let xDesc = realX.logDescription()
 
             // Check that the key dependency is either explicity declared or
             // recursive/self-referential.
             guard K.versionDependencies.contains(where: { $0 == X.self }) || X.self == K.self else {
                 throw Error.unexpressedKeyDependency(
-                    from: kDesc,
-                    to: xDesc
+                    from: key.internalKey.logDescription(),
+                    to: realX.logDescription()
                 )
             }
 

--- a/Sources/llbuild2fx/WrappedDataID.swift
+++ b/Sources/llbuild2fx/WrappedDataID.swift
@@ -41,7 +41,10 @@ extension FXSingleDataIDValue {
 
 extension FXSingleDataIDValue {
     public func encode(to encoder: Encoder) throws {
-        try encoder.encodeHash(of: ArraySlice<UInt8>(dataID.bytes))
+        // Since we already have a hash value, directly encode a short prefix of it
+        var container = encoder.singleValueContainer()
+        let str = ArraySlice(dataID.bytes.dropFirst().prefix(9)).base64URL()
+        try container.encode(str)
     }
 }
 


### PR DESCRIPTION
- Fix cache key prefix memoization
- Avoid double hashing SingleDataIDValue's
- Bypass command line args encoder for hinted keys
- Defer calculation of logDescription until actually needed for
  unexpressed dependency errors