### PR TITLE
Allow TypedCachingFunctions to recompute on cache failures

### DIFF
--- a/Sources/llbuild2fx/Key.swift
+++ b/Sources/llbuild2fx/Key.swift
@@ -145,6 +145,9 @@ public enum FXError: Swift.Error {
 
 
 final class FXFunction<K: FXKey>: LLBTypedCachingFunction<InternalKey<K>, InternalValue<K.ValueType>> {
+
+    override var recomputeOnCacheFailure: Bool { true }
+
     override func compute(key: InternalKey<K>, _ fi: LLBFunctionInterface, _ ctx: Context) -> LLBFuture<
         InternalValue<K.ValueType>
     > {


### PR DESCRIPTION
Adopt recomputation by default in the FX engine.

rdar://89755290