### PR TITLE
Fix deprecation warnings

### DIFF
--- a/Sources/LLBBuildSystemUtil/LocalExecutor.swift
+++ b/Sources/LLBBuildSystemUtil/LocalExecutor.swift
@@ -121,7 +121,6 @@ final public class LLBLocalExecutor: LLBExecutor {
                     environment: preActionEnvironment,
                     workingDirectory: self.outputBase.appending(RelativePath(request.actionSpec.workingDirectory)),
                     outputRedirection: .collect,
-                    verbose: false,
                     startNewProcessGroup: false
                 )
 
@@ -146,7 +145,6 @@ final public class LLBLocalExecutor: LLBExecutor {
                 environment: environment,
                 workingDirectory: workingDir,
                 outputRedirection: .collect(redirectStderr: true),
-                verbose: false,
                 startNewProcessGroup: false
             )
 

--- a/Sources/LLBCommands/NinjaBuildTool.swift
+++ b/Sources/LLBCommands/NinjaBuildTool.swift
@@ -29,7 +29,7 @@ public struct NinjaBuildTool: ParsableCommand {
 
     public func run() throws {
         let dryRunDelegate = NinjaDryRunDelegate()
-        let nb = try NinjaBuild(manifest: manifest, delegate: dryRunDelegate)
+        let nb = try NinjaBuild(manifest: manifest, workingDirectory: "/", delegate: dryRunDelegate)
         let ctx = Context()
         _ = try nb.build(target: target, as: Int.self, ctx)
     }

--- a/Tests/LLBNinjaTests/NinjaBuildTests.swift
+++ b/Tests/LLBNinjaTests/NinjaBuildTests.swift
@@ -21,7 +21,7 @@ final class NinjaBuildTests: XCTestCase {
         return try withTemporaryFile { tmp in
             try localFileSystem.writeFileContents(tmp.path, bytes: ByteString((manifest + "\n").utf8))
             let logger = LoggingNinjaDelegate()
-            let nb = try NinjaBuild(manifest: tmp.path.pathString, delegate: logger)
+            let nb = try NinjaBuild(manifest: tmp.path.pathString, workingDirectory: "/", delegate: logger)
             let ctx = Context()
             _ = try nb.build(target: "all", as: Int.self, ctx)
             return logger.log


### PR DESCRIPTION
NinjaBuild now requires a "workingDirectory" argument. The default from the deprecated initializer was "/" so this PR just specifies that value directly to avoid the warning.