### PR TITLE
Record full keys for llbuild2fx InternalValues

### DIFF
--- a/Sources/llbuild2fx/Key.swift
+++ b/Sources/llbuild2fx/Key.swift
@@ -161,7 +161,7 @@ final class FXFunction<K: FXKey>: LLBTypedCachingFunction<InternalKey<K>, Intern
         ctx.fxBuildEngineStats.add(key: key.name)
 
         let fxfi = FXFunctionInterface(actualKey, fi)
-        return actualKey.computeValue(fxfi, ctx).flatMapError { underlyingError in
+        let value: LLBFuture<K.ValueType> = actualKey.computeValue(fxfi, ctx).flatMapError { underlyingError in
             let augmentedError: Swift.Error
 
             do {
@@ -182,8 +182,14 @@ final class FXFunction<K: FXKey>: LLBTypedCachingFunction<InternalKey<K>, Intern
             }
 
             return ctx.group.next().makeFailedFuture(augmentedError)
-        }.map { value in
-            InternalValue(value, requestedCacheKeyPaths: fxfi.requestedCacheKeyPathsSnapshot)
+        }
+
+        let encodedKey = (try? FXEncoder().encode(actualKey)) ?? Data()
+        let buffer = LLBByteBufferAllocator().buffer(bytes: ArraySlice<UInt8>(encodedKey))
+        let keyID = ctx.db.put(LLBCASObject(refs: [], data: buffer), ctx)
+
+        return value.and(keyID).map { value, keyID in
+            InternalValue(value, requestedCacheKeyPaths: fxfi.requestedCacheKeyPathsSnapshot, keyID: keyID)
         }.always { _ in
             ctx.fxBuildEngineStats.remove(key: key.name)
         }


### PR DESCRIPTION
It has been very difficult or even impossible to determine why a requested key was not found in the cache, e.g., when re-running a build with a few changes. Only the key information reflected in the InternalValue.cachePath was recorded. This change adds a reference in every InternalValue to the full JSON-encoded key for that value. With this, you can do things like comparing two builds to see exactly what differs in their requested keys.

This is implemented by encoding each key as JSON in the CAS and then adding a CAS reference as the first element in the refs for an InternalValue. Note that this is an incompatible change in the encoding of InternalValue that needs to be versioned appropriately.