### PR TITLE
Add FXEncodedKeyID function to access the new encoded key info

### DIFF
--- a/Sources/llbuild2fx/Value.swift
+++ b/Sources/llbuild2fx/Value.swift
@@ -170,6 +170,12 @@ public func FXRequestedCacheKeyPaths(for cachedValue: LLBCASObject) throws -> FX
     return keyPaths
 }
 
+// Get the JSON-encoded key associated with a cached value
+public func FXEncodedKeyID(for cachedValue: LLBCASObject) throws -> LLBDataID {
+    let internalValue = try InternalValue<IgnoredValue>(from: cachedValue)
+    return internalValue.keyID
+}
+
 struct FXValueMetadata: Codable {
     let requestedCacheKeyPaths: FXSortedSet<String>?
 


### PR DESCRIPTION
Given a cached value, this function provides access to the encoded key associated with that value.