### PR TITLE
Add the ability to annotate `FXKey`s with configuration inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ Utilities/tools
 xcuserdata
 Examples/*/.build
 Examples/*/.swiftpm
+/.vscode

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/grpc/grpc-swift.git",
         "state": {
           "branch": null,
-          "revision": "9e464a75079928366aa7041769a271fac89271bf",
-          "version": "1.0.0"
+          "revision": "87cecdeb2aae6b359b754d0dc7099e8237cf1824",
+          "version": "1.11.0"
         }
       },
       {
@@ -26,6 +26,15 @@
           "branch": null,
           "revision": "919eb1d83e02121cdb434c7bfc1f0c66ef17febe",
           "version": "1.0.2"
+        }
+      },
+      {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections.git",
+        "state": {
+          "branch": null,
+          "revision": "f504716c27d2e5d4144fa4794b12129301d17729",
+          "version": "1.0.3"
         }
       },
       {
@@ -51,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "173f567a2dfec11d74588eea82cecea555bdc0bc",
-          "version": "1.4.0"
+          "revision": "6fe203dc33195667ce1759bf0182975e4653ba1c",
+          "version": "1.4.4"
         }
       },
       {
@@ -60,8 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "b4e0a274f7f34210e97e2f2c50ab02a10b549250",
-          "version": "2.41.1"
+          "revision": "bc4c55b9f9584f09eb971d67d956e28d08caa9d0",
+          "version": "2.43.1"
         }
       },
       {
@@ -78,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "f4736a3b78a2bbe3feb7fc0f33f6683a8c27974c",
-          "version": "1.16.3"
+          "revision": "00576e6f1efa5c46dca2ca3081dc56dd233b402d",
+          "version": "1.23.0"
         }
       },
       {
@@ -87,8 +96,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "4c933e955b8797f5a5a90bd2a0fb411fdb11bb94",
-          "version": "2.10.3"
+          "revision": "4fb7ead803e38949eb1d6fabb849206a72c580f3",
+          "version": "2.23.0"
         }
       },
       {
@@ -96,8 +105,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "1d28d48e071727f4558a8a4bb1894472abc47a58",
-          "version": "1.9.2"
+          "revision": "c0d9a144cfaec8d3d596aadde3039286a266c15c",
+          "version": "1.15.0"
         }
       },
       {
@@ -105,8 +114,8 @@
         "repositoryURL": "https://github.com/apple/swift-protobuf.git",
         "state": {
           "branch": null,
-          "revision": "e1904bf5a5f79cb7e0ff68a427a53a93b652fcd1",
-          "version": "1.15.0"
+          "revision": "88c7d15e1242fdb6ecbafbc7926426a19be1e98a",
+          "version": "1.20.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -20,9 +20,9 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-llbuild.git", from: "0.5.0"),
         .package(url: "https://github.com/apple/swift-tools-support-async.git", from: "0.8.3"),
         .package(url: "https://github.com/apple/swift-tools-support-core.git", .upToNextMinor(from: "0.2.7")),
-        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.8.0"),
-        .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.2.0"),
+        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.17.0"),
+        .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.4.1"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.4.2"),
     ],
     targets: [
         // Core build functionality

--- a/Sources/llbuild2/Core/KeyDependencyGraph.swift
+++ b/Sources/llbuild2/Core/KeyDependencyGraph.swift
@@ -32,7 +32,7 @@ public class LLBKeyDependencyGraph {
     /// An active edge is one where its future is not completed yet.
     private var activeEdges: [ActiveEdge: Int] = [:]
 
-    private let lock = Lock()
+    private let lock = NIOLock()
 
     public init() {
         self.edges = [:]

--- a/Sources/llbuild2/FunctionCache/InMemoryFunctionCache.swift
+++ b/Sources/llbuild2/FunctionCache/InMemoryFunctionCache.swift
@@ -18,7 +18,7 @@ public final class LLBInMemoryFunctionCache: LLBFunctionCache {
     public let group: LLBFuturesDispatchGroup
 
     /// The lock protecting content.
-    let lock = NIOConcurrencyHelpers.Lock()
+    let lock = NIOConcurrencyHelpers.NIOLock()
 
     /// Create an in-memory database.
     public init(group: LLBFuturesDispatchGroup) {
@@ -30,6 +30,6 @@ public final class LLBInMemoryFunctionCache: LLBFunctionCache {
     }
 
     public func update(key: LLBKey, value: LLBDataID, _ ctx: Context) -> LLBFuture<Void> {
-        return group.next().makeSucceededFuture(lock.withLockVoid { cache[Key(key)] = value })
+        return group.next().makeSucceededFuture(lock.withLock { cache[Key(key)] = value })
     }
 }

--- a/Sources/llbuild2fx/Coding.swift
+++ b/Sources/llbuild2fx/Coding.swift
@@ -50,3 +50,10 @@ extension Encoder {
         try container.encode(str)
     }
 }
+
+extension Encodable {
+    public func fxEncodeJSON() throws -> String {
+        let encoder = FXEncoder()
+        return try String(decoding: encoder.encode(self), as: UTF8.self)
+    }
+}

--- a/Sources/llbuild2fx/Engine.swift
+++ b/Sources/llbuild2fx/Engine.swift
@@ -70,7 +70,7 @@ public final class FXBuildEngine {
         _ ctx: Context
     ) -> LLBFuture<K.ValueType> {
         let ctx = engineContext(ctx)
-        return engine.build(key: key.internalKey, as: InternalValue<K.ValueType>.self, ctx).map { internalValue in
+        return engine.build(key: key.internalKey(ctx), as: InternalValue<K.ValueType>.self, ctx).map { internalValue in
             internalValue.value
         }
     }

--- a/Sources/llbuild2fx/FunctionInterface.swift
+++ b/Sources/llbuild2fx/FunctionInterface.swift
@@ -20,7 +20,7 @@ public final class FXFunctionInterface<K: FXKey> {
     private let key: K
     private let fi: LLBFunctionInterface
     private var requestedKeyCachePaths = FXSortedSet<String>()
-    private let lock = Lock()
+    private let lock = NIOLock()
     var requestedCacheKeyPathsSnapshot: FXSortedSet<String> {
         lock.withLock {
             requestedKeyCachePaths

--- a/Sources/llbuild2fx/FunctionInterface.swift
+++ b/Sources/llbuild2fx/FunctionInterface.swift
@@ -34,13 +34,13 @@ public final class FXFunctionInterface<K: FXKey> {
 
     public func request<X: FXKey>(_ x: X, requireCacheHit: Bool = false, _ ctx: Context) -> LLBFuture<X.ValueType> {
         do {
-            let realX = x.internalKey
+            let realX = x.internalKey(ctx)
 
             // Check that the key dependency is either explicity declared or
             // recursive/self-referential.
             guard K.versionDependencies.contains(where: { $0 == X.self }) || X.self == K.self else {
                 throw Error.unexpressedKeyDependency(
-                    from: key.internalKey.logDescription(),
+                    from: key.internalKey(ctx).logDescription(),
                     to: realX.logDescription()
                 )
             }

--- a/Sources/llbuild2fx/Key.swift
+++ b/Sources/llbuild2fx/Key.swift
@@ -41,7 +41,7 @@ extension FXKey {
 }
 
 private struct FXCacheKeyPrefixMemoizer {
-    private static let lock = Lock()
+    private static let lock = NIOLock()
     private static var prefixes: [ObjectIdentifier: String] = [:]
 
     static func get<K: FXVersioning>(for key: K) -> String {

--- a/Sources/llbuild2fx/KeyConfiguration.swift
+++ b/Sources/llbuild2fx/KeyConfiguration.swift
@@ -1,0 +1,60 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import Foundation
+
+extension FXVersioning {
+    public func getConfigurationInputs(_ ctx: Context) -> KeyConfiguration<Self> {
+        KeyConfiguration(inputs: ctx.fxConfigurationInputs)
+    }
+}
+
+public typealias FXConfigurationInputs = [String: Encodable]
+
+extension Context {
+    public var fxConfigurationInputs: FXConfigurationInputs! {
+        get {
+            return self[ObjectIdentifier(FXConfigurationInputs.self)] as? FXConfigurationInputs
+        }
+        set {
+            self[ObjectIdentifier(FXConfigurationInputs.self)] = newValue
+        }
+    }
+}
+
+/// KeyConfiguration represents a grab-bag of information that could inform various steps of
+/// the build. For example, it's the ideal container for information from an A/B testing or
+/// feature-flag system. It ensures that only the configuration explicitly requested by a
+/// given FXKey is visible to that key, and that the cache key is set up appropriately
+/// so that if a downstream key starts requesting more configuration, we actually recalculate
+/// appropriately.
+public final class KeyConfiguration<K: FXVersioning>: Encodable {
+    private let inputs: FXConfigurationInputs
+    private let allowedInputs: FXSortedSet<String>
+
+    init(inputs: FXConfigurationInputs) {
+        self.inputs = inputs
+        self.allowedInputs = FXSortedSet<String>(K.configurationKeys)
+    }
+
+    public func get<T>(_ key: String) -> T? {
+        if !allowedInputs.contains(key) {
+            return nil
+        }
+        return inputs[key] as? T
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        let allPossibleAllowed = K.aggregatedConfigurationKeys
+        try encoder.fxEncodeHash(of: try inputs.filter{ (k, _) in allPossibleAllowed.contains(k) }.mapValues { (val: Encodable) -> String in try val.fxEncodeJSON() })
+    }
+
+    func isNoop() -> Bool {
+        return self.allowedInputs.isEmpty && K.aggregatedConfigurationKeys.isEmpty
+    }
+}

--- a/Sources/llbuild2fx/Stats.swift
+++ b/Sources/llbuild2fx/Stats.swift
@@ -17,7 +17,7 @@ public struct FXBuildEngineStatsSnapshot {
 }
 
 public final class FXBuildEngineStats {
-    private let lock = Lock()
+    private let lock = NIOLock()
 
     private var currentKeyCounts: [String: Int] = [:]
     private var totalKeyCounts: [String: Int] = [:]

--- a/Sources/llbuild2fx/Versioning.swift
+++ b/Sources/llbuild2fx/Versioning.swift
@@ -10,6 +10,7 @@ public protocol FXVersioning {
     static var name: String { get }
     static var version: Int { get }
     static var versionDependencies: [FXVersioning.Type] { get }
+    static var configurationKeys: [String] { get }
 }
 
 extension FXKey {
@@ -17,6 +18,15 @@ extension FXKey {
     public static var version: Int { 0 }
     public static var versionDependencies: [FXVersioning.Type] {
         [FXVersioning.Type]()
+    }
+    public static var configurationKeys: [String] {
+        [String]()
+    }
+}
+
+extension FXVersioning {
+    public static var configurationKeys: [String] {
+        [String]()
     }
 }
 
@@ -48,7 +58,7 @@ extension FXVersioning {
         return Array(settled.values)
     }
 
-    private static var aggregatedVersionDependencies: [FXVersioning.Type] {
+    static var aggregatedVersionDependencies: [FXVersioning.Type] {
         aggregateGraph {
             $0.versionDependencies
         }
@@ -56,6 +66,10 @@ extension FXVersioning {
 
     static var aggregatedVersion: Int {
         return aggregatedVersionDependencies.map { $0.version }.reduce(0, +)
+    }
+
+    public static var aggregatedConfigurationKeys: FXSortedSet<String> {
+        return FXSortedSet<String>(aggregatedVersionDependencies.map { $0.configurationKeys }.reduce([], +))
     }
 
     public static var cacheKeyPrefix: String {


### PR DESCRIPTION
Designed to be used in conjunction with code that can apply feature
flags to the build, this code allows us to do dependency injection
instead of propagating flags through a tree in a way that is worse for
the cache.