### PR TITLE
Import NIOCore and LLBUtil to fix build warnings

### DIFF
--- a/Sources/LLBBazelBackend/CAS/BazelCASDatabase.swift
+++ b/Sources/LLBBazelBackend/CAS/BazelCASDatabase.swift
@@ -12,6 +12,7 @@ import llbuild2
 
 import BazelRemoteAPI
 import GRPC
+import NIOCore
 import SwiftProtobuf
 import TSCBasic
 

--- a/Sources/LLBBuildSystem/BuildEngine.swift
+++ b/Sources/LLBBuildSystem/BuildEngine.swift
@@ -7,6 +7,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import llbuild2
+import NIOCore
 
 public enum LLBBuildEngineError: Error {
     case unknownBuildKeyIdentifier(String)

--- a/Sources/LLBBuildSystem/ConfiguredTargetDelegate.swift
+++ b/Sources/LLBBuildSystem/ConfiguredTargetDelegate.swift
@@ -7,6 +7,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import llbuild2
+import NIOCore
 
 /// An enum representing the available types of dependencies.
 public enum LLBTargetDependency {

--- a/Sources/LLBBuildSystem/DynamicActionDelegate.swift
+++ b/Sources/LLBBuildSystem/DynamicActionDelegate.swift
@@ -7,6 +7,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import llbuild2
+import NIOCore
 
 public typealias LLBDynamicActionIdentifier = String
 

--- a/Sources/LLBBuildSystem/Function.swift
+++ b/Sources/LLBBuildSystem/Function.swift
@@ -7,6 +7,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import llbuild2
+import NIOCore
 
 /// An "abstract" class that represents a build function, which includes a way to
 /// statically specify the types of the build keys and values.

--- a/Sources/LLBBuildSystem/Functions/Evaluation/RuleEvaluation.swift
+++ b/Sources/LLBBuildSystem/Functions/Evaluation/RuleEvaluation.swift
@@ -7,6 +7,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import llbuild2
+import NIOCore
 
 extension LLBRuleEvaluationKeyID: LLBBuildKey {}
 extension LLBRuleEvaluationKey: LLBSerializable {}

--- a/Sources/LLBBuildSystem/Functions/Execution/ActionID.swift
+++ b/Sources/LLBBuildSystem/Functions/Execution/ActionID.swift
@@ -7,6 +7,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import llbuild2
+import NIOCore
 
 // Mark ActionKey as an LLBBuildValue so that it can be returned by the ActionIDFunction. Since LLBBuildValue is a
 // subset of LLBBuildKey, any LLBBuildKey can be made to conform to LLBBuildValue for free.

--- a/Sources/LLBBuildSystem/Rules/Rule.swift
+++ b/Sources/LLBBuildSystem/Rules/Rule.swift
@@ -7,6 +7,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import llbuild2
+import NIOCore
 
 /// Protocol definition for a rule lookup delegate, which looks up the rule definition for a given configured target
 /// type.

--- a/Sources/LLBBuildSystem/Rules/RuleContext.swift
+++ b/Sources/LLBBuildSystem/Rules/RuleContext.swift
@@ -9,6 +9,7 @@
 import llbuild2
 import Dispatch
 import Foundation
+import NIOCore
 
 public typealias LLBPreAction = (arguments: [String], environment: [String: String], background: Bool)
 

--- a/Sources/LLBBuildSystemTestHelpers/ByteBuffer.swift
+++ b/Sources/LLBBuildSystemTestHelpers/ByteBuffer.swift
@@ -8,6 +8,7 @@
 
 import llbuild2
 import Foundation
+import NIOCore
 
 /// Helper extension for creating LLBByteBuffers from Data.
 public extension LLBByteBuffer {

--- a/Sources/LLBBuildSystemTestHelpers/TestCASDatabase.swift
+++ b/Sources/LLBBuildSystemTestHelpers/TestCASDatabase.swift
@@ -7,6 +7,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import llbuild2
+import NIOCore
 
 
 /// Implementation of an LLBCASDatabase to be used for tests purposes.

--- a/Sources/LLBBuildSystemUtil/Codable.swift
+++ b/Sources/LLBBuildSystemUtil/Codable.swift
@@ -9,6 +9,7 @@
 import LLBBuildSystem
 import Foundation
 import llbuild2
+import NIOCore
 import SwiftProtobuf
 
 // This file is a collection of extensions that make Codable adoption easier for

--- a/Sources/LLBBuildSystemUtil/LocalExecutor.swift
+++ b/Sources/LLBBuildSystemUtil/LocalExecutor.swift
@@ -10,6 +10,7 @@ import Foundation
 import llbuild2
 import TSCBasic
 import Dispatch
+import NIOCore
 
 public enum LLBLocalExecutorError: Error {
     case unimplemented(String)

--- a/Sources/LLBNinja/NinjaBuild.swift
+++ b/Sources/LLBNinja/NinjaBuild.swift
@@ -8,6 +8,7 @@
 
 import llbuild2
 import LLBUtil
+import NIOCore
 
 import llbuildSwift
 

--- a/Sources/LLBUtil/CommonCodables.swift
+++ b/Sources/LLBUtil/CommonCodables.swift
@@ -7,6 +7,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import llbuild2
+import NIOCore
 
 // LLBCodable support for common types used in llbuild2. Should be expanded as more types are needed. This is not
 // meant ot be a full featured serialization library support, so there's no need to be eager and add support for most of

--- a/Sources/LLBUtil/SimpleFunction.swift
+++ b/Sources/LLBUtil/SimpleFunction.swift
@@ -7,7 +7,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import llbuild2
-
+import NIOCore
 
 public class LLBSimpleFunction: LLBFunction {
     let action: (_ fi: LLBFunctionInterface, _ key: LLBKey, _ ctx: Context) -> LLBFuture<LLBValue>

--- a/Sources/LLBUtil/StaticFunctionDelegate.swift
+++ b/Sources/LLBUtil/StaticFunctionDelegate.swift
@@ -7,7 +7,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import llbuild2
-
+import NIOCore
 
 extension String: LLBKey {
     public var stableHashValue: LLBDataID {

--- a/Sources/llbuild2/Core/Engine.swift
+++ b/Sources/llbuild2/Core/Engine.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 import NIOConcurrencyHelpers
+import NIOCore
 import TSCUtility
 
 // Explicitly re-export all of Futures/Utility/CAS/CASFileTree for easy of use

--- a/Sources/llbuild2/EngineProtocol/Executor.swift
+++ b/Sources/llbuild2/EngineProtocol/Executor.swift
@@ -6,6 +6,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+import NIOCore
 
 /// Protocol definition for an executor that can fullfil action execution requests.
 public protocol LLBExecutor {

--- a/Sources/llbuild2/EngineProtocol/Protobuf+Extensions.swift
+++ b/Sources/llbuild2/EngineProtocol/Protobuf+Extensions.swift
@@ -8,7 +8,7 @@
 
 import SwiftProtobuf
 import Foundation
-
+import NIOCore
 
 /// Convenience implementation for types that extend SwiftProtobuf.Message.
 extension LLBSerializableOut where Self: SwiftProtobuf.Message {

--- a/Sources/llbuild2/FunctionCache/InMemoryFunctionCache.swift
+++ b/Sources/llbuild2/FunctionCache/InMemoryFunctionCache.swift
@@ -7,7 +7,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import NIOConcurrencyHelpers
-
+import NIOCore
 
 /// A simple in-memory implementation of the `LLBFunctionCache` protocol.
 public final class LLBInMemoryFunctionCache: LLBFunctionCache {

--- a/Sources/llbuild2fx/Action.swift
+++ b/Sources/llbuild2fx/Action.swift
@@ -7,10 +7,10 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import Foundation
+import NIOCore
 import TSCUtility
 import TSFCAS
 import TSFFutures
-
 
 public protocol FXAction: FXValue {
     associatedtype ValueType: FXValue

--- a/Sources/llbuild2fx/Diagnostics.swift
+++ b/Sources/llbuild2fx/Diagnostics.swift
@@ -6,6 +6,8 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+import NIOCore
+
 public struct FXDiagnostics: FXThinEncodedSingleDataIDValue, FXTreeID {
     public let dataID: LLBDataID
     public init(dataID: LLBDataID) {

--- a/Sources/llbuild2fx/Engine.swift
+++ b/Sources/llbuild2fx/Engine.swift
@@ -7,6 +7,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import Logging
+import NIOCore
 import TSFCAS
 import TSFFutures
 import llbuild2

--- a/Sources/llbuild2fx/Executor.swift
+++ b/Sources/llbuild2fx/Executor.swift
@@ -10,6 +10,7 @@ import TSCUtility
 import TSFCAS
 import TSFFutures
 import llbuild2
+import NIOCore
 
 public protocol FXExecutor {
     func canSatisfy<P: Predicate>(requirements: P) -> Bool where P.EvaluatedType == FXActionExecutionEnvironment

--- a/Sources/llbuild2fx/FunctionCache.swift
+++ b/Sources/llbuild2fx/FunctionCache.swift
@@ -7,6 +7,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import Logging
+import NIOCore
 import TSCUtility
 import llbuild2
 

--- a/Sources/llbuild2fx/FunctionInterface.swift
+++ b/Sources/llbuild2fx/FunctionInterface.swift
@@ -7,6 +7,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import NIOConcurrencyHelpers
+import NIOCore
 import llbuild2
 
 public final class FXFunctionInterface<K: FXKey> {

--- a/Sources/llbuild2fx/Key.swift
+++ b/Sources/llbuild2fx/Key.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import NIOConcurrencyHelpers
+import NIOCore
 import TSCUtility
 import llbuild2
 

--- a/Sources/llbuild2fx/LocalExecutor.swift
+++ b/Sources/llbuild2fx/LocalExecutor.swift
@@ -6,6 +6,8 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+import NIOCore
+
 extension FXActionExecutionEnvironment {
     private final class ContextKey {}
     private static let key = ContextKey()

--- a/Sources/llbuild2fx/NullExecutor.swift
+++ b/Sources/llbuild2fx/NullExecutor.swift
@@ -6,6 +6,8 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+import NIOCore
+
 public final class FXNullExecutor: FXExecutor {
     public init() {}
 

--- a/Sources/llbuild2fx/SpawnProcess.swift
+++ b/Sources/llbuild2fx/SpawnProcess.swift
@@ -7,6 +7,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import Foundation
+import NIOCore
 import TSCBasic
 import TSCUtility
 import TSFCAS

--- a/Sources/llbuild2fx/TreeMaterialization.swift
+++ b/Sources/llbuild2fx/TreeMaterialization.swift
@@ -7,6 +7,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import Foundation
+import NIOCore
 import TSCBasic
 import TSCUtility
 import TSFCASFileTree

--- a/Sources/llbuild2fx/WrappedDataID.swift
+++ b/Sources/llbuild2fx/WrappedDataID.swift
@@ -6,6 +6,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+import NIOCore
 import TSFCAS
 import llbuild2
 

--- a/Tests/LLBBuildSystemTests/ConfiguredTargetTests.swift
+++ b/Tests/LLBBuildSystemTests/ConfiguredTargetTests.swift
@@ -9,6 +9,7 @@
 import llbuild2
 import LLBBuildSystem
 import LLBBuildSystemTestHelpers
+import LLBUtil
 import TSCBasic
 import XCTest
 

--- a/Tests/LLBBuildSystemTests/DynamicActionTests.swift
+++ b/Tests/LLBBuildSystemTests/DynamicActionTests.swift
@@ -11,6 +11,7 @@ import Foundation
 import LLBBuildSystem
 import LLBBuildSystemTestHelpers
 import LLBBuildSystemUtil
+import LLBUtil
 import TSCBasic
 import XCTest
 

--- a/Tests/llbuild2fxTests/EngineTests.swift
+++ b/Tests/llbuild2fxTests/EngineTests.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 
+import NIOCore
 import TSFCAS
 import TSFFutures
 import llbuild2fx


### PR DESCRIPTION
Swift 5.8 complains about use of type aliases from modules that are not explicitly imported.