### PR TITLE
Remove unused swift-nio dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,6 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.17.0"),
         .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.4.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.2"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.46.0"),
     ],
     targets: [
         // Core build functionality


### PR DESCRIPTION
SwiftPM complains that this package dependency is unused, so remove it.