### PR TITLE
Use throwing AbsolutePath initializers to fix deprecation warnings

### DIFF
--- a/Sources/LLBBuildSystemUtil/LocalExecutor.swift
+++ b/Sources/LLBBuildSystemUtil/LocalExecutor.swift
@@ -74,7 +74,7 @@ final public class LLBLocalExecutor: LLBExecutor {
                         LLBCASFileTree.export(
                             input.dataID,
                             from: ctx.db,
-                            to: .init(fullInputPath.pathString),
+                            to: fullInputPath,
                             ctx
                         ).always { _ in
                             self.statsObserver?.stopObserving(stats)

--- a/Sources/Tools/llcastool/misc.swift
+++ b/Sources/Tools/llcastool/misc.swift
@@ -25,8 +25,9 @@ extension AbsolutePath: ExpressibleByArgument {
     public init?(argument: String) {
         if let path = try? AbsolutePath(validating: argument) {
             self = path
-        } else if let cwd = localFileSystem.currentWorkingDirectory {
-            self = AbsolutePath(argument, relativeTo: cwd)
+        } else if let cwd = localFileSystem.currentWorkingDirectory,
+                  let path = try? AbsolutePath(validating: argument, relativeTo: cwd) {
+            self = path
         } else {
             return nil
         }

--- a/Tests/llbuild2Tests/FunctionCacheTests.swift
+++ b/Tests/llbuild2Tests/FunctionCacheTests.swift
@@ -16,7 +16,7 @@ final class FunctionCacheTests: XCTestCase {
 
     /// ${TMPDIR} or just "/tmp", expressed as AbsolutePath
     private var temporaryPath: AbsolutePath {
-        return AbsolutePath(ProcessInfo.processInfo.environment["TMPDIR", default: "/tmp"])
+        return try! AbsolutePath(validating: ProcessInfo.processInfo.environment["TMPDIR", default: "/tmp"])
     }
 
     func doFunctionCacheTests(cache: LLBFunctionCache) throws {


### PR DESCRIPTION
Hello there!

I was just getting started and tinkering with llbuild2, and noticed there are `AbsolutePath` deprecation warnings, so I cleaned them up:
- `AbsolutePath: ExpressibleByArgument` — if the argument is not a valid path, the initializer will return `nil`.
- `LocalExecutor` — the `fullInputPath` is already an `AbsolutePath`, so we can just pass it to `.export`, without copying it with `.init`, right?
- `FunctionCacheTests` — since that's in unit tests, and the argument defaults to `/tmp`, it's probably okay to `try!` here?

Tried `swift build` and `swift test` locally, and things seem to work fine.

I hope this is useful. Not trying to waste anyone's time with small PRs, I'm here to learn.