### PR TITLE
Action execution adjustments

### DIFF
--- a/Sources/llbuild2fx/Action.swift
+++ b/Sources/llbuild2fx/Action.swift
@@ -11,16 +11,32 @@ import NIOCore
 import TSCUtility
 import TSFFutures
 
+public struct FXActionRequirements {
+    public let predicate: (any Predicate)?
+
+    public init(predicate: (any Predicate)? = nil) {
+        self.predicate = predicate
+    }
+}
+
 public protocol FXAction: FXValue {
     associatedtype ValueType: FXValue
 
+    static var name: String { get }
     static var version: Int { get }
+
+    var requirements: FXActionRequirements { get }
 
     func run(_ ctx: Context) -> LLBFuture<ValueType>
 }
 
 extension FXAction {
+    public static var name: String { String(describing: self) }
     public static var version: Int { 0 }
+
+    public var requirements: FXActionRequirements {
+        FXActionRequirements()
+    }
 }
 
 public protocol AsyncFXAction: FXAction {
@@ -34,3 +50,4 @@ extension AsyncFXAction {
         }
     }
 }
+

--- a/Sources/llbuild2fx/Executor.swift
+++ b/Sources/llbuild2fx/Executor.swift
@@ -11,8 +11,14 @@ import TSFFutures
 import NIOCore
 
 public protocol FXExecutor {
+    func perform<ActionType: FXAction>(
+        _ action: ActionType,
+        _ ctx: Context
+    ) -> LLBFuture<ActionType.ValueType>
+
     func canSatisfy<P: Predicate>(requirements: P) -> Bool where P.EvaluatedType == FXActionExecutionEnvironment
 
+    @available(*, deprecated, message: "use self-resolving perform")
     func perform<ActionType: FXAction, P: Predicate>(
         action: ActionType,
         with executable: LLBFuture<FXExecutableID>,

--- a/Sources/llbuild2fx/Key.swift
+++ b/Sources/llbuild2fx/Key.swift
@@ -386,8 +386,3 @@ extension AsyncFXKey {
     }
 }
 
-extension FXFunctionInterface {
-    public func request<X: FXKey>(_ x: X, requireCacheHit: Bool = false, _ ctx: Context) async throws -> X.ValueType {
-        return try await request(x, requireCacheHit: requireCacheHit, ctx).get()
-    }
-}

--- a/Sources/llbuild2fx/LocalExecutor.swift
+++ b/Sources/llbuild2fx/LocalExecutor.swift
@@ -43,6 +43,12 @@ public final class FXLocalExecutor: FXExecutor {
         self.environment = env
     }
 
+    public func perform<ActionType: FXAction>(
+        _ action: ActionType, _ ctx: Context
+    ) -> LLBFuture<ActionType.ValueType> {
+        return action.run(ctx)
+    }
+
     public func canSatisfy<P: Predicate>(requirements: P) -> Bool where P.EvaluatedType == FXActionExecutionEnvironment {
         requirements.evaluate(with: environment)
     }

--- a/Sources/llbuild2fx/NullExecutor.swift
+++ b/Sources/llbuild2fx/NullExecutor.swift
@@ -11,6 +11,13 @@ import NIOCore
 public final class FXNullExecutor: FXExecutor {
     public init() {}
 
+    public func perform<ActionType: FXAction>(
+        _ action: ActionType,
+        _ ctx: Context
+    ) -> LLBFuture<ActionType.ValueType> {
+        return ctx.group.any().makeFailedFuture(Error.nullExecutor)
+    }
+
     public func canSatisfy<P: Predicate>(requirements: P) -> Bool where P.EvaluatedType == FXActionExecutionEnvironment {
         false
     }
@@ -25,6 +32,6 @@ public final class FXNullExecutor: FXExecutor {
         requirements: P,
         _ ctx: Context
     ) -> LLBFuture<ActionType.ValueType> where P.EvaluatedType == FXActionExecutionEnvironment {
-        ctx.group.next().makeFailedFuture(Error.nullExecutor)
+        return ctx.group.any().makeFailedFuture(Error.nullExecutor)
     }
 }

--- a/Sources/llbuild2fx/Ruleset.swift
+++ b/Sources/llbuild2fx/Ruleset.swift
@@ -9,6 +9,8 @@
 public class FXRuleset {
     public let name: String
     public let entrypoints: [String : FXVersioning.Type]
+    public let actionDependencies: [any FXAction.Type]
+
     let aggregatedResourceEntitlements: FXSortedSet<ResourceKey>
 
     public init(name: String, entrypoints: [String: FXVersioning.Type]) {
@@ -16,6 +18,14 @@ public class FXRuleset {
         self.entrypoints = entrypoints
 
         aggregatedResourceEntitlements = FXSortedSet<ResourceKey>(entrypoints.values.map { $0.aggregatedResourceEntitlements }.reduce([], +))
+
+        var actionDeps: [String: any FXAction.Type] = [:]
+        for ep in entrypoints.values {
+            for ad in ep.aggregatedActionDependencies {
+                actionDeps[ad.name] = ad
+            }
+        }
+        actionDependencies = Array(actionDeps.values)
     }
 
     public func constrainResources(_ resources: [ResourceKey: FXResource]) throws -> [ResourceKey: FXResource] {

--- a/Sources/llbuild2fx/Versioning.swift
+++ b/Sources/llbuild2fx/Versioning.swift
@@ -19,6 +19,7 @@ public protocol FXVersioning: Sendable {
     static var name: String { get }
     static var version: Int { get }
     static var versionDependencies: [FXVersioning.Type] { get }
+    static var actionDependencies: [any FXAction.Type] { get }
     static var configurationKeys: [ConfigurationKey] { get }
     static var resourceEntitlements: [ResourceKey] { get }
 }
@@ -29,6 +30,9 @@ extension FXKey {
     public static var versionDependencies: [FXVersioning.Type] {
         [FXVersioning.Type]()
     }
+    public static var actionDependencies: [any FXAction.Type] {
+        [any FXAction.Type]()
+    }
     public static var configurationKeys: [ConfigurationKey] {
         [ConfigurationKey]()
     }
@@ -38,6 +42,9 @@ extension FXKey {
 }
 
 extension FXVersioning {
+    public static var actionDependencies: [any FXAction.Type] {
+        [any FXAction.Type]()
+    }
     public static var configurationKeys: [ConfigurationKey] {
         [ConfigurationKey]()
     }
@@ -90,6 +97,16 @@ extension FXVersioning {
 
     public static var aggregatedResourceEntitlements: FXSortedSet<ResourceKey> {
         return FXSortedSet<ResourceKey>(aggregatedVersionDependencies.map { $0.resourceEntitlements }.reduce([], +))
+    }
+
+    public static var aggregatedActionDependencies: [any FXAction.Type] {
+        var actionDeps: [String: any FXAction.Type] = [:]
+        for dep in aggregatedVersionDependencies {
+            for ad in dep.aggregatedActionDependencies {
+                actionDeps[ad.name] = ad
+            }
+        }
+        return Array(actionDeps.values)
     }
 
     public static var cacheKeyPrefix: String {


### PR DESCRIPTION
- Add action dependencies specification and enforcement
- Add new, simpler `spawn` call for actions
- Add stub mechanism for collecting requirements from action instances
- Deprecate `execute` (and associated `perform`) in favor of expecting the FXExecutor to resolve how to execute the `run` method