### PR TITLE
Update FXActionRequirements

### DIFF
--- a/Sources/llbuild2fx/Action.swift
+++ b/Sources/llbuild2fx/Action.swift
@@ -11,11 +11,16 @@ import NIOCore
 import TSCUtility
 import TSFFutures
 
-public struct FXActionRequirements {
-    public let predicate: (any Predicate)?
+public enum FXActionWorkerSize: Equatable {
+    case small
+    case large
+}
 
-    public init(predicate: (any Predicate)? = nil) {
-        self.predicate = predicate
+public struct FXActionRequirements {
+    public let workerSize: FXActionWorkerSize?
+
+    public init(workerSize: FXActionWorkerSize? = nil) {
+        self.workerSize = workerSize
     }
 }
 
@@ -25,18 +30,12 @@ public protocol FXAction: FXValue {
     static var name: String { get }
     static var version: Int { get }
 
-    var requirements: FXActionRequirements { get }
-
     func run(_ ctx: Context) -> LLBFuture<ValueType>
 }
 
 extension FXAction {
     public static var name: String { String(describing: self) }
     public static var version: Int { 0 }
-
-    public var requirements: FXActionRequirements {
-        FXActionRequirements()
-    }
 }
 
 public protocol AsyncFXAction: FXAction {
@@ -50,4 +49,3 @@ extension AsyncFXAction {
         }
     }
 }
-

--- a/Sources/llbuild2fx/Executor.swift
+++ b/Sources/llbuild2fx/Executor.swift
@@ -6,13 +6,14 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+import NIOCore
 import TSCUtility
 import TSFFutures
-import NIOCore
 
 public protocol FXExecutor: Sendable {
     func perform<ActionType: FXAction>(
         _ action: ActionType,
+        requirements: FXActionRequirements?,
         _ ctx: Context
     ) -> LLBFuture<ActionType.ValueType>
 
@@ -30,6 +31,13 @@ public protocol FXExecutor: Sendable {
 extension FXExecutor {
     func canSatisfy<P: Predicate>(requirements: P) -> Bool where P.EvaluatedType == FXActionExecutionEnvironment {
         true
+    }
+
+    func perform<ActionType: FXAction>(
+        _ action: ActionType,
+        _ ctx: Context
+    ) -> LLBFuture<ActionType.ValueType> {
+        return perform(action, requirements: nil, ctx)
     }
 }
 

--- a/Sources/llbuild2fx/LocalExecutor.swift
+++ b/Sources/llbuild2fx/LocalExecutor.swift
@@ -44,7 +44,7 @@ public final class FXLocalExecutor: FXExecutor {
     }
 
     public func perform<ActionType: FXAction>(
-        _ action: ActionType, _ ctx: Context
+        _ action: ActionType, requirements: FXActionRequirements?, _ ctx: Context
     ) -> LLBFuture<ActionType.ValueType> {
         return action.run(ctx)
     }

--- a/Sources/llbuild2fx/NullExecutor.swift
+++ b/Sources/llbuild2fx/NullExecutor.swift
@@ -13,6 +13,7 @@ public final class FXNullExecutor: FXExecutor {
 
     public func perform<ActionType: FXAction>(
         _ action: ActionType,
+        requirements: FXActionRequirements?,
         _ ctx: Context
     ) -> LLBFuture<ActionType.ValueType> {
         return ctx.group.any().makeFailedFuture(Error.nullExecutor)


### PR DESCRIPTION
- Remove stub 'predicate' value
- Add support for worker size hint
- Return to call site specified requirements for greater flexibilty