### PR TITLE
Add a TaskCancellationRegistry to cancel unstructured tasks

### DIFF
--- a/Sources/llbuild2fx/Action.swift
+++ b/Sources/llbuild2fx/Action.swift
@@ -44,8 +44,8 @@ public protocol AsyncFXAction: FXAction {
 
 extension AsyncFXAction {
     public func run(_ ctx: Context) -> LLBFuture<ValueType> {
-        ctx.group.any().makeFutureWithTask {
-            try await run(ctx)
-        }
+        TaskCancellationRegistry.makeCancellableTask({
+            try await self.run(ctx)
+        }, ctx)
     }
 }

--- a/Sources/llbuild2fx/Key.swift
+++ b/Sources/llbuild2fx/Key.swift
@@ -362,9 +362,9 @@ public protocol AsyncFXKey: FXKey {
 
 extension AsyncFXKey {
     public func computeValue(_ fi: FXFunctionInterface<Self>, _ ctx: Context) -> LLBFuture<ValueType> {
-        ctx.group.any().makeFutureWithTask {
-            try await computeValue(fi, ctx)
-        }
+        TaskCancellationRegistry.makeCancellableTask({
+            try await self.computeValue(fi, ctx)
+        }, ctx)
     }
 
     public func fixCached(value: ValueType, _ fi: FXFunctionInterface<Self>, _ ctx: Context) -> LLBFuture<ValueType?> {

--- a/Sources/llbuild2fx/TaskCancellationRegistry.swift
+++ b/Sources/llbuild2fx/TaskCancellationRegistry.swift
@@ -1,0 +1,75 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import Foundation
+import NIOConcurrencyHelpers
+
+public final class TaskCancellationRegistry {
+    private var triggers: NIOLockedValueBox<[UUID: () -> Void]> = NIOLockedValueBox([:])
+
+    public init() {
+
+    }
+
+    public func registerForCancellation(_ trigger: @escaping () -> Void) -> UUID {
+        let uuid = UUID()
+        triggers.withLockedValue { triggers in
+            triggers[uuid] = trigger
+        }
+        return uuid
+    }
+
+    public func deregisterForCancellation(taskID uuid: UUID) {
+        triggers.withLockedValue { triggers in
+            triggers[uuid] = nil
+        }
+    }
+
+    public func cancelAllTasks() {
+        triggers.withLockedValue { triggers in
+            for (_, trigger) in triggers {
+                trigger()
+            }
+            triggers = [:]
+        }
+    }
+
+    static func makeCancellableTask<ValueType>(_ fn: @escaping () async throws -> ValueType, _ ctx: Context) -> LLBFuture<ValueType> {
+        let promise = ctx.group.any().makePromise(of: ValueType.self)
+
+        // This creates a new unstrcutured Task context which will not be cancelled when our potentially parent Task context is cancelled. Capture the task here and register it with task cancellation registery so clients can explicitly handle cancellation of the unstrcutured Task created.
+        let task = promise.completeWithTask {
+            try await fn()
+        }
+
+        var taskUUID: UUID?
+        if let taskCancellationRegistry = ctx.taskCancellationRegistry {
+            taskUUID = taskCancellationRegistry.registerForCancellation {
+                task.cancel()
+            }
+        }
+
+        return promise.futureResult.always { _ in
+            if let taskUUID = taskUUID {
+                ctx.taskCancellationRegistry?.deregisterForCancellation(taskID: taskUUID)
+            }
+        }
+    }
+}
+
+extension Context {
+    public var taskCancellationRegistry: TaskCancellationRegistry? {
+        get {
+            return (self[ObjectIdentifier(TaskCancellationRegistry.self), as: TaskCancellationRegistry.self])
+        }
+        set {
+            self[ObjectIdentifier(TaskCancellationRegistry.self)] = newValue
+        }
+    }
+}
+


### PR DESCRIPTION
This allows clients to cancel unstructured tasks that are created when we bridge from NIO to Swift Concurrency.