### PR TITLE
[SpawnProcess] Add ProcessSpec to StreamingLogHandler

### DIFF
--- a/Sources/llbuild2fx/SpawnProcess.swift
+++ b/Sources/llbuild2fx/SpawnProcess.swift
@@ -205,7 +205,7 @@ public struct ProcessSpec: Codable, Sendable {
         guard let streamingLogHandler = ctx.streamingLogHandler, let channel = channel else {
             return { _ in () }
         }
-        return { try await streamingLogHandler.streamLog(channel: channel, $0) }
+        return { try await streamingLogHandler.streamLog(spec: self, channel: channel, $0) }
     }
 
     private enum OutputSource {

--- a/Sources/llbuild2fx/Support/Logging.swift
+++ b/Sources/llbuild2fx/Support/Logging.swift
@@ -36,7 +36,7 @@ extension FXMetricsSink {
 
 /// Protocol for streaming log messages during FXAction evaluations. (Useful for capturing the output of spawned processes while they're still running.)
 public protocol StreamingLogHandler {
-    func streamLog(channel: String, _ data: LLBByteBuffer) async throws
+    func streamLog(spec: ProcessSpec, channel: String, _ data: LLBByteBuffer) async throws
 }
 
 // Support storing and retrieving logger, metrics, and file handle generator instances from a Context.

--- a/Tests/llbuild2fxTests/SpawnProcessTests.swift
+++ b/Tests/llbuild2fxTests/SpawnProcessTests.swift
@@ -201,7 +201,7 @@ final class SpawnProcessTests: XCTestCase {
 class StreamAccumulator: StreamingLogHandler {
     var accumulatedLogs: [String: String] = [:]
 
-    func streamLog(channel: String, _ data: LLBByteBuffer) {
+    func streamLog(spec: ProcessSpec, channel: String, _ data: LLBByteBuffer) {
         accumulatedLogs[channel, default: ""].append(String(buffer: data))
     }
 }


### PR DESCRIPTION
This will allow clients to distingush streams coming from different spawn processes.