### PR TITLE
Change FXDataIDProtocol.bytes from Data to [UInt8]

### DIFF
--- a/Sources/FXCore/CAS/DataID.swift
+++ b/Sources/FXCore/CAS/DataID.swift
@@ -47,16 +47,19 @@ extension FXDataID: Hashable, CustomDebugStringConvertible {
         ])
     }
 
+    /// The raw bytes of the digest as a `[UInt8]` array.
+    public var bytes: [UInt8] { Array(rawBytes) }
+
     public init?(bytes: [UInt8]) {
         let data = Data(bytes)
         guard DataIDKind(from: data) != nil else {
             return nil
         }
-        self.bytes = data
+        self.rawBytes = data
     }
 
     public init(directHash bytes: [UInt8]) {
-        self.bytes = Data([DataIDKind.directHash.rawValue] + bytes)
+        self.rawBytes = Data([DataIDKind.directHash.rawValue] + bytes)
     }
 
     /// Initialize from the string form.
@@ -79,7 +82,7 @@ extension FXDataID: Hashable, CustomDebugStringConvertible {
             return nil
         }
 
-        self.bytes = Data(completeBytes)
+        self.rawBytes = Data(completeBytes)
     }
 }
 

--- a/Sources/FXCore/CAS/DataIDProtocol.swift
+++ b/Sources/FXCore/CAS/DataIDProtocol.swift
@@ -14,7 +14,7 @@ import Foundation
 /// ``FXDataID`` type conforms to this protocol.
 public protocol FXDataIDProtocol: Codable, Comparable, Hashable, Sendable {
     /// The raw bytes of the digest.
-    var bytes: Data { get }
+    var bytes: [UInt8] { get }
 
     /// Create from raw bytes, returning nil if the bytes are invalid.
     init?(bytes: [UInt8])

--- a/Sources/FXCore/CAS/Generated/data_id.pb.swift
+++ b/Sources/FXCore/CAS/Generated/data_id.pb.swift
@@ -37,7 +37,7 @@ public struct FXDataID {
   // methods supported on all messages.
 
   //// The bytes containing the digest of the contents store in the CAS.
-  public var bytes: Data = Data()
+  public var rawBytes: Data = Data()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -62,21 +62,21 @@ extension FXDataID: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationB
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try { try decoder.decodeSingularBytesField(value: &self.bytes) }()
+      case 1: try { try decoder.decodeSingularBytesField(value: &self.rawBytes) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if !self.bytes.isEmpty {
-      try visitor.visitSingularBytesField(value: self.bytes, fieldNumber: 1)
+    if !self.rawBytes.isEmpty {
+      try visitor.visitSingularBytesField(value: self.rawBytes, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: FXDataID, rhs: FXDataID) -> Bool {
-    if lhs.bytes != rhs.bytes {return false}
+    if lhs.rawBytes != rhs.rawBytes {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Tests/FXInteropTests/TSFInteropTests.swift
+++ b/Tests/FXInteropTests/TSFInteropTests.swift
@@ -15,14 +15,14 @@ import llbuild2Testing
 extension FXDataID {
     init(fromTSF tsfID: LLBDataID) {
         self.init()
-        self.bytes = tsfID.bytes
+        self.rawBytes = tsfID.bytes
     }
 }
 
 extension LLBDataID {
     init(fromFX fxID: FXDataID) {
         self.init()
-        self.bytes = fxID.bytes
+        self.bytes = Data(fxID.bytes)
     }
 }
 


### PR DESCRIPTION
Rename the protobuf stored property to rawBytes and add a computed bytes: [UInt8] property so clients get a native array while protobuf encode/decode continues to use Data internally.