### PR TITLE
Add buildUnchecked

### DIFF
--- a/Sources/llbuild2fx/Engine.swift
+++ b/Sources/llbuild2fx/Engine.swift
@@ -206,6 +206,36 @@ extension FXEngine: EngineInternalProtocol {
         }
     }
 
+    /// Build a type-erased key and return its serialized CAS representation.
+    ///
+    /// Use when the concrete `FXKey` type is only known at runtime (e.g. after
+    /// opening an existential metatype). The key must have `ValueType.DataID ==
+    /// DB.DataID`; this is checked at runtime via the `CallableKey` cast.
+    public func buildUnchecked(key: any FXKey, _ ctx: Context) -> FXFuture<FXCASObject> {
+        let ctx = engineContext(ctx)
+        func _doBuild<K: FXKey>(_ key: K) -> FXFuture<FXCASObject> {
+            let ikey = InternalKey(unchecked: key, engine: self, ctx: ctx)
+            return self.buildInternal(key: ikey, ctx).flatMapThrowing { result in
+                guard let iv = result as? InternalValue<K.ValueType> else {
+                    throw FXError.invalidValueType("Expected InternalValue<\(K.ValueType.self)>")
+                }
+                // Encode the value to CAS representation manually.
+                // InternalValue.asCASObject() requires DataID == FXDataID
+                // which we can't prove here, but the encoding doesn't
+                // depend on DataID — refs are cast through [UInt8].
+                let data = try FXEncoder().encode(iv.value.codableValue)
+                let buffer = FXByteBufferAllocator().buffer(bytes: ArraySlice<UInt8>(data))
+                let refs = iv.value.refs.map { FXDataID(bytes: [UInt8]($0.bytes))! }
+                return FXCASObject(refs: refs, data: buffer)
+            }
+        }
+        return _openExistential(key, do: _doBuild)
+    }
+
+    internal func buildInternal(key: FXRequestKey, _ ctx: Context) -> FXFuture<InternalResult> {
+        return build(key: key, ctx)
+    }
+
     internal func build(key: FXRequestKey, _ ctx: Context) -> FXFuture<InternalResult> {
         let ctx = engineContext(ctx)
         return self.pendingResults.value(for: HashableKey(key: key)) { _ in

--- a/Sources/llbuild2fx/Key.swift
+++ b/Sources/llbuild2fx/Key.swift
@@ -108,6 +108,35 @@ internal final class InternalKey<K: FXKey>: @unchecked Sendable {
         let treeService = engine.treeService
         self._function = { TypedFunction<K, DB>(db: db, cache: cache, treeService: treeService) }
     }
+
+    /// Creates an InternalKey without proving the `DataID` constraint at
+    /// compile time. The caller guarantees `K.ValueType.DataID == DB.DataID`
+    /// holds at runtime. Used by ``FXEngine/buildUnchecked(key:_:)`` for
+    /// existential key dispatch.
+    init<DB: FXTypedCASDatabase>(
+        unchecked key: K, engine: FXEngine<DB>, ctx: Context
+    ) {
+        self.name = String(describing: K.self)
+        self.key = key
+        self.ctx = ctx
+        let cachePath = Self.calculateCachePath(
+            key: key,
+            cacheRequestOnly: engine.cacheRequestOnly,
+            buildID: engine.buildID,
+            resources: engine.resources,
+            ctx: ctx
+        )
+        let hashData = Array(cachePath.utf8)
+        self.stableHashValue = FXDataID(blake3hash: hashData[...])
+        self.cachePath = cachePath
+        let db = engine.db
+        let cache = engine.cache
+        let treeService = engine.treeService
+        // TypedFunction<K, DB> requires K.ValueType.DataID == DB.DataID at the
+        // type level. At runtime this is always true for keys dispatched through
+        // buildUnchecked. We use _makeUncheckedFunction to bypass the constraint.
+        self._function = { _makeUncheckedFunction(K.self, db: db, cache: cache, treeService: treeService) }
+    }
 }
 
 extension InternalKey: FXKeyProperties {
@@ -245,6 +274,44 @@ extension Context {
         set {
             self[ObjectIdentifier(TraceIDKey.self)] = newValue
         }
+    }
+}
+
+/// Constructs a `GenericFunction` for key type `K` using database `DB`,
+/// without requiring `K.ValueType.DataID == DB.DataID` at the call site.
+/// The caller must guarantee the types match at runtime.
+///
+/// We can't construct TypedFunction<K, DB> directly (it carries the where
+/// clause). Instead we construct TypedFunction<_AnyKey<DB.DataID>, DB> —
+/// which satisfies the constraint trivially — and unsafeBitCast the result.
+/// This is safe because TypedFunction's stored properties (db, cache,
+/// treeService) only depend on DB, and its methods dispatch through the
+/// key's FXKey conformance which is resolved at runtime.
+private func _makeUncheckedFunction<K: FXKey, DB: FXTypedCASDatabase>(
+    _ keyType: K.Type,
+    db: DB,
+    cache: any FXFunctionCache<DB.DataID>,
+    treeService: (any FXTypedCASTreeService<DB.DataID>)?
+) -> any GenericFunction<K.ValueType.DataID> {
+    let fn: any GenericFunction<DB.DataID> = TypedFunction<_AnyKey<DB.DataID>, DB>(
+        db: db, cache: cache, treeService: treeService
+    )
+    return unsafeBitCast(fn, to: (any GenericFunction<K.ValueType.DataID>).self)
+}
+
+/// Minimal FXKey stub whose ValueType.DataID matches a given DataID.
+/// Used only by `_makeUncheckedFunction` to satisfy TypedFunction's
+/// where clause at construction time.
+private struct _AnyKey<DID: FXDataIDProtocol>: FXKey {
+    struct Value: FXValue, Codable {
+        typealias DataID = DID
+        var refs: [DID] { [] }
+        var codableValue: Value { self }
+        init(refs: [DID], codableValue: Value) { self = codableValue }
+    }
+    typealias ValueType = Value
+    func computeValue(_ fi: FXFunctionInterface<Self>, _ ctx: Context) -> FXFuture<Value> {
+        fatalError("_AnyKey should never be evaluated")
     }
 }
 


### PR DESCRIPTION
If we retrieve the entrypoint key as `any FXKey`, then `engine.build` will try to enforce this equality constraint:

> "Key’s `DataID` data type being equal to databases’s `DataID` datatype". 

This equality constraint is not true for `any FXKey` even if all entrypoints use the same `FXDataID` that the database uses.